### PR TITLE
Align ruff and black settings by disabling E501

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -63,6 +63,7 @@ select = [
     "RUF",    # ruff-specific rules
 ]
 ignore = [
+    "E501",    # Line too long (handled by black)
     "S101",    # Use of assert detected (ok in tests)
 ]
 


### PR DESCRIPTION
Disable ruff's line length check (E501) since black handles all
formatting. Keep both tools at line-length = 100 for consistency.