### PR TITLE
Refactor main.lua plugin into modular architecture

### DIFF
--- a/clients/koreader-plugin/copy_to_pocketbook.sh
+++ b/clients/koreader-plugin/copy_to_pocketbook.sh
@@ -36,11 +36,13 @@ sed -i 's/description = _(\[\[Syncs your highlights to Crossbill server for edit
 # Change the class name
 sed -i 's/name = "Crossbill"/name = "Crossbill Test"/' "$TMP_TEST_DIR/crossbill-test.koplugin/main.lua"
 
+# Modify modules/settings.lua for test version
 # Change settings key to separate from production version
-sed -i 's/crossbill_sync/crossbill_test_sync/g' "$TMP_TEST_DIR/crossbill-test.koplugin/main.lua"
+sed -i 's/crossbill_sync/crossbill_test_sync/g' "$TMP_TEST_DIR/crossbill-test.koplugin/modules/settings.lua"
 
+# Modify modules/ui.lua for test version
 # Change menu text
-sed -i 's/_("Crossbill Sync")/_("Crossbill Test Sync")/g' "$TMP_TEST_DIR/crossbill-test.koplugin/main.lua"
+sed -i 's/_("Crossbill Sync")/_("Crossbill Test Sync")/g' "$TMP_TEST_DIR/crossbill-test.koplugin/modules/ui.lua"
 
 # Copy test plugin to destination
 cp -R "$TMP_TEST_DIR/crossbill-test.koplugin" "$KOREADER_PLUGINS_PATH/"

--- a/clients/koreader-plugin/crossbill.koplugin/main.lua
+++ b/clients/koreader-plugin/crossbill.koplugin/main.lua
@@ -1,455 +1,73 @@
+--[[
+Crossbill Sync Plugin for KOReader
+
+A plugin to synchronize book highlights with a Crossbill server.
+Supports manual sync, auto-sync on suspend/exit, and cover image uploads.
+]]
+
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
-local UIManager = require("ui/uimanager")
-local InfoMessage = require("ui/widget/infomessage")
-local MultiInputDialog = require("ui/widget/multiinputdialog")
-local DocSettings = require("docsettings")
-local NetworkMgr = require("ui/network/manager")
-local socket = require("socket")
-local http = require("socket.http")
-local https = require("ssl.https")
-local ltn12 = require("ltn12")
-local socketutil = require("socketutil")
-local JSON = require("json")
 local logger = require("logger")
-local _ = require("gettext")
-local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
+
+local Settings = require("modules/settings")
+local Network = require("modules/network")
+local Auth = require("modules/auth")
+local ApiClient = require("modules/api_client")
+local HighlightExtractor = require("modules/highlight_extractor")
+local BookMetadata = require("modules/book_metadata")
+local UI = require("modules/ui")
 
 local CrossbillSync = WidgetContainer:extend({
 	name = "Crossbill",
 	is_doc_only = true, -- Only show when document is open
 })
 
+--- Initialize the plugin
 function CrossbillSync:init()
-	-- Load settings
-	self.settings = G_reader_settings:readSetting("crossbill_sync")
-		or {
-			base_url = "http://localhost:8000",
-			username = "",
-			password = "",
-			autosync_enabled = false,
-			-- Token caching for refresh token support
-			access_token = nil,
-			refresh_token = nil,
-			token_expires_at = nil,
-		}
+	-- Initialize settings
+	self.settings = Settings:new():load()
 
+	-- Initialize authentication with settings
+	self.auth = Auth:new(self.settings)
+
+	-- Initialize API client with settings and auth
+	self.api_client = ApiClient:new(self.settings, self.auth)
+
+	-- Register menu
 	self.ui.menu:registerToMainMenu(self)
-
-	-- Register event handlers for autosync
-	self:registerEventHandlers()
-
-	-- Track whether we enabled WiFi (so we can turn it off after sync)
-	self.wifi_was_enabled_by_us = false
 end
 
+--- Add plugin menu items to KOReader main menu
 function CrossbillSync:addToMainMenu(menu_items)
-	menu_items.crossbill_sync = {
-		text = _("Crossbill Sync"),
-		sorting_hint = "tools",
-		sub_item_table = {
-			{
-				text = _("Sync Current Book"),
-				callback = function()
-					self:syncCurrentBook()
-				end,
-			},
-			{
-				text = _("Configure Server"),
-				callback = function()
-					self:configureServer()
-				end,
-			},
-			{
-				text = _("Auto-sync"),
-				checked_func = function()
-					return self.settings.autosync_enabled
-				end,
-				callback = function()
-					self.settings.autosync_enabled = not self.settings.autosync_enabled
-					G_reader_settings:saveSetting("crossbill_sync", self.settings)
-					UIManager:show(InfoMessage:new({
-						text = self.settings.autosync_enabled and _("Auto-sync enabled") or _("Auto-sync disabled"),
-					}))
-				end,
-			},
-		},
-	}
-end
-
-function CrossbillSync:configureServer()
-	local settings_dialog
-	settings_dialog = MultiInputDialog:new({
-		title = _("Crossbill Settings"),
-		fields = {
-			{
-				text = self.settings.base_url or "",
-				hint = _("Server URL (e.g., https://example.com)"),
-			},
-			{
-				text = self.settings.username or "",
-				hint = _("Username"),
-			},
-			{
-				text = self.settings.password or "",
-				hint = _("Password"),
-				text_type = "password",
-			},
-		},
-		buttons = {
-			{
-				{
-					text = _("Cancel"),
-					callback = function()
-						UIManager:close(settings_dialog)
-					end,
-				},
-				{
-					text = _("Save"),
-					is_enter_default = true,
-					callback = function()
-						local fields = settings_dialog:getFields()
-						-- Remove trailing slash from URL if present
-						self.settings.base_url = fields[1]:gsub("/$", "")
-						self.settings.username = fields[2]
-						self.settings.password = fields[3]
-						G_reader_settings:saveSetting("crossbill_sync", self.settings)
-						UIManager:close(settings_dialog)
-						UIManager:show(InfoMessage:new({
-							text = _("Settings saved"),
-						}))
-					end,
-				},
-			},
-		},
+	menu_items.crossbill_sync = UI.buildMenuItems({
+		on_sync = function()
+			self:syncCurrentBook()
+		end,
+		on_configure = function()
+			self:configureServer()
+		end,
+		is_autosync_enabled = function()
+			return self.settings:isAutosyncEnabled()
+		end,
+		on_toggle_autosync = function()
+			local enabled = self.settings:toggleAutosync()
+			UI.showAutosyncToggled(enabled)
+		end,
 	})
-	UIManager:show(settings_dialog)
-	settings_dialog:onShowKeyboard()
 end
 
-function CrossbillSync:urlEncode(str)
-	-- URL encode a string for use in form-urlencoded data
-	if str then
-		str = string.gsub(str, "\n", "\r\n")
-		str = string.gsub(str, "([^%w _%%%-%.~])", function(c)
-			return string.format("%%%02X", string.byte(c))
-		end)
-		str = string.gsub(str, " ", "+")
-	end
-	return str
+--- Show server configuration dialog
+function CrossbillSync:configureServer()
+	UI.showConfigureServerDialog(self.settings)
 end
 
-function CrossbillSync:login()
-	-- Authenticate with the server and return an access token
-	-- Returns token string on success, nil on failure
-	-- Also stores refresh_token and token_expires_at for later use
-	local username = self.settings.username or ""
-	local password = self.settings.password or ""
-
-	if username == "" or password == "" then
-		logger.warn("Crossbill: Username or password not configured")
-		return nil, "Username or password not configured"
-	end
-
-	local api_url = self.settings.base_url .. "/api/v1/auth/login"
-	logger.dbg("Crossbill: Logging in to", api_url)
-
-	-- Prepare form-urlencoded body
-	local body = "username=" .. self:urlEncode(username) .. "&password=" .. self:urlEncode(password)
-
-	local response_body = {}
-	local request = {
-		url = api_url,
-		method = "POST",
-		headers = {
-			["Content-Type"] = "application/x-www-form-urlencoded",
-			["Accept"] = "application/json",
-			["Content-Length"] = tostring(#body),
-		},
-		source = ltn12.source.string(body),
-		sink = ltn12.sink.table(response_body),
-	}
-
-	local code
-	if api_url:match("^https://") then
-		code = socket.skip(1, https.request(request))
-	else
-		code = socket.skip(1, http.request(request))
-	end
-	socketutil:reset_timeout()
-
-	if code == 200 then
-		local response_text = table.concat(response_body)
-		local ok, response_data = pcall(JSON.decode, response_text)
-		if ok and response_data.access_token then
-			logger.dbg("Crossbill: Login successful")
-			-- Store tokens for refresh support
-			self.settings.access_token = response_data.access_token
-			self.settings.refresh_token = response_data.refresh_token
-			if response_data.expires_in then
-				self.settings.token_expires_at = os.time() + response_data.expires_in
-			end
-			G_reader_settings:saveSetting("crossbill_sync", self.settings)
-			return response_data.access_token
-		else
-			logger.err("Crossbill: Invalid login response:", response_text)
-			return nil, "Invalid server response"
-		end
-	else
-		logger.err("Crossbill: Login failed with code:", code)
-		return nil, "Login failed: " .. tostring(code)
-	end
-end
-
-function CrossbillSync:refreshToken()
-	-- Refresh the access token using the stored refresh token
-	-- Returns new access token on success, nil on failure
-	local refresh_token = self.settings.refresh_token
-	if not refresh_token then
-		logger.dbg("Crossbill: No refresh token available")
-		return nil, "No refresh token"
-	end
-
-	local api_url = self.settings.base_url .. "/api/v1/auth/refresh"
-	logger.dbg("Crossbill: Refreshing token at", api_url)
-
-	-- Send refresh token in request body (for plugin clients)
-	local body = JSON.encode({ refresh_token = refresh_token })
-
-	local response_body = {}
-	local request = {
-		url = api_url,
-		method = "POST",
-		headers = {
-			["Content-Type"] = "application/json",
-			["Accept"] = "application/json",
-			["Content-Length"] = tostring(#body),
-		},
-		source = ltn12.source.string(body),
-		sink = ltn12.sink.table(response_body),
-	}
-
-	local code
-	if api_url:match("^https://") then
-		code = socket.skip(1, https.request(request))
-	else
-		code = socket.skip(1, http.request(request))
-	end
-	socketutil:reset_timeout()
-
-	if code == 200 then
-		local response_text = table.concat(response_body)
-		local ok, response_data = pcall(JSON.decode, response_text)
-		if ok and response_data.access_token then
-			logger.dbg("Crossbill: Token refresh successful")
-			-- Store new tokens
-			self.settings.access_token = response_data.access_token
-			self.settings.refresh_token = response_data.refresh_token
-			if response_data.expires_in then
-				self.settings.token_expires_at = os.time() + response_data.expires_in
-			end
-			G_reader_settings:saveSetting("crossbill_sync", self.settings)
-			return response_data.access_token
-		else
-			logger.err("Crossbill: Invalid refresh response:", response_text)
-			return nil, "Invalid server response"
-		end
-	else
-		logger.err("Crossbill: Token refresh failed with code:", code)
-		-- Clear stored tokens on refresh failure
-		self.settings.access_token = nil
-		self.settings.refresh_token = nil
-		self.settings.token_expires_at = nil
-		G_reader_settings:saveSetting("crossbill_sync", self.settings)
-		return nil, "Refresh failed: " .. tostring(code)
-	end
-end
-
-function CrossbillSync:getValidToken()
-	-- Get a valid access token, refreshing or re-authenticating if needed
-	-- Returns token string on success, nil on failure
-	local current_time = os.time()
-	local expires_at = self.settings.token_expires_at
-
-	-- Check if we have a cached token that's still valid (with 60s buffer)
-	if self.settings.access_token and expires_at and (expires_at - 60) > current_time then
-		logger.dbg("Crossbill: Using cached access token")
-		return self.settings.access_token
-	end
-
-	-- Try to refresh the token if we have a refresh token
-	if self.settings.refresh_token then
-		logger.dbg("Crossbill: Access token expired or missing, trying refresh")
-		local token, err = self:refreshToken()
-		if token then
-			return token
-		end
-		logger.dbg("Crossbill: Refresh failed:", err)
-	end
-
-	-- Fall back to full login
-	logger.dbg("Crossbill: Falling back to full login")
-	return self:login()
-end
-
-function CrossbillSync:ensureWifiEnabled(callback)
-	-- Enable WiFi if needed using NetworkMgr (the proper KOReader way)
-	-- This will prompt user or auto-enable based on settings
-	if NetworkMgr:willRerunWhenOnline(callback) then
-		-- Network is off, NetworkMgr will call callback when online
-		logger.info("crossbill: WiFi is off, prompting to enable...")
-		self.wifi_was_enabled_by_us = true
-		return false
-	else
-		-- Network is already on
-		logger.info("crossbill: WiFi already enabled")
-		self.wifi_was_enabled_by_us = false
-		return true
-	end
-end
-
-function CrossbillSync:disableWifiIfNeeded()
-	-- Disable WiFi if we enabled it for the sync
-	if self.wifi_was_enabled_by_us then
-		logger.info("crossbill: Disabling WiFi after sync")
-		NetworkMgr:turnOffWifi()
-		self.wifi_was_enabled_by_us = false
-	else
-		logger.info("crossbill: WiFi was already on, leaving it enabled")
-	end
-end
-
-function CrossbillSync:performSync(is_autosync)
-	-- The actual sync logic (separated so it can be called after WiFi is enabled)
-	-- is_autosync: if true, don't show result popup (silent mode)
-
-	-- Safety check: ensure document is available
-	-- This prevents crashes when switching books (especially on Pocketbook)
-	if not self.ui.document then
-		logger.warn("Crossbill: Cannot sync - no document available")
-		return
-	end
-
-	if not is_autosync then
-		UIManager:show(InfoMessage:new({
-			text = _("Syncing highlights..."),
-			timeout = 2,
-		}))
-	end
-
-	local success, err = pcall(function()
-		-- Get book metadata
-		local book_props = self.ui.doc_props
-		local doc_path = self.ui.document.file
-
-		logger.dbg("Crossbill: Syncing book:", book_props.display_title or book_props.title or doc_path)
-
-		-- Extract ISBN from identifiers if available
-		-- First try from self.ui.doc_props, then fall back to reading from DocSettings
-		local isbn = nil
-		local doc_settings = DocSettings:open(doc_path)
-		local metadata_props = doc_settings:readSetting("doc_props") or book_props
-
-		if metadata_props.identifiers then
-			-- Try to extract ISBN from identifiers string
-			-- The format can vary - identifiers may be separated by newlines, spaces, or concatenated
-			-- Examples: "ISBN:9780735211292\nAMAZON:..." or "ISBN:9780735211292 AMAZON:..."
-			-- ISBNs are numeric with possible hyphens and X (for ISBN-10)
-			-- Match ISBN: followed by digits/hyphens/X until we hit a non-ISBN character or end of string
-			isbn = metadata_props.identifiers:match("ISBN:([%d%-xX]+)")
-			if isbn then
-				logger.dbg("Crossbill: Extracted ISBN:", isbn)
-			else
-				logger.dbg("Crossbill: No ISBN found in identifiers:", metadata_props.identifiers)
-			end
-		else
-			logger.dbg("Crossbill: No identifiers field found in metadata")
-		end
-
-		-- Extract language code if available
-		local language = metadata_props.language or nil
-		if language then
-			logger.dbg("Crossbill: Extracted language:", language)
-		end
-
-		-- Extract page count from document
-		local page_count = doc_settings:readSetting("doc_pages") or nil
-		if page_count then
-			logger.dbg("Crossbill: Extracted page count:", page_count)
-		end
-
-		-- Extract keywords and split into array
-		local keywords = nil
-		if metadata_props.keywords then
-			keywords = {}
-			-- Keywords can be separated by newlines (backslash-newline in Lua string)
-			for keyword in metadata_props.keywords:gmatch("[^\n]+") do
-				local trimmed = keyword:match("^%s*(.-)%s*$") -- trim whitespace
-				if trimmed and trimmed ~= "" then
-					table.insert(keywords, trimmed)
-				end
-			end
-			if #keywords > 0 then
-				logger.dbg("Crossbill: Extracted", #keywords, "keywords")
-			else
-				keywords = nil
-			end
-		end
-
-		local book_data = {
-			title = book_props.display_title or book_props.title or self:getFilename(doc_path),
-			author = book_props.authors or nil,
-			isbn = isbn,
-			description = metadata_props.description or nil,
-			language = language,
-			page_count = page_count,
-			keywords = keywords,
-		}
-
-		-- Get highlights from memory (ReaderAnnotation) if available,
-		-- otherwise fall back to reading from DocSettings file
-		local highlights = self:getHighlightsFromMemory() or self:getHighlights(doc_path)
-
-		if not highlights or #highlights == 0 then
-			return
-		end
-
-		logger.dbg("Crossbill: Found", #highlights, "highlights")
-
-		-- Get chapter number mapping from table of contents
-		local chapter_number_map = self:getChapterNumberMap()
-
-		-- Add chapter numbers to highlights based on their chapter names
-		for _, highlight in ipairs(highlights) do
-			if highlight.chapter and chapter_number_map[highlight.chapter] then
-				highlight.chapter_number = chapter_number_map[highlight.chapter]
-			end
-		end
-
-		-- Send to server
-		self:sendToServer(book_data, highlights, is_autosync)
-	end)
-
-	if not success then
-		logger.err("Crossbill: Error in syncCurrentBook:", err)
-		UIManager:show(InfoMessage:new({
-			text = _("Error syncing book: ") .. tostring(err),
-			timeout = 5,
-		}))
-	end
-
-	-- Always disable WiFi after sync completes (success or failure)
-	self:disableWifiIfNeeded()
-end
-
+--- Sync the currently open book's highlights
+-- @param is_autosync boolean If true, run in silent mode (no UI feedback)
 function CrossbillSync:syncCurrentBook(is_autosync)
-	-- Ensure WiFi is enabled before attempting to sync
-	-- NetworkMgr will handle prompting user or auto-enabling based on settings
-	-- is_autosync: if true, don't show result popup (silent mode)
 	local callback = function()
 		self:performSync(is_autosync)
 	end
 
-	if not self:ensureWifiEnabled(callback) then
+	if not Network.ensureWifiEnabled(callback) then
 		-- WiFi is being enabled, callback will be called when ready
 		logger.info("Crossbill: Waiting for WiFi to be enabled...")
 	else
@@ -458,348 +76,133 @@ function CrossbillSync:syncCurrentBook(is_autosync)
 	end
 end
 
-function CrossbillSync:getHighlightsFromMemory()
-	-- Try to get highlights directly from ReaderAnnotation's memory
-	-- This avoids the issue where DocSettings hasn't been flushed to disk yet
-	if not self.ui.annotation then
-		logger.dbg("Crossbill: ReaderAnnotation module not available")
-		return nil
+--- Perform the actual sync operation
+-- @param is_autosync boolean If true, run in silent mode
+function CrossbillSync:performSync(is_autosync)
+	-- Safety check: ensure document is available
+	if not self.ui.document then
+		logger.warn("Crossbill: Cannot sync - no document available")
+		return
 	end
 
-	local annotations = self.ui.annotation.annotations
-	if not annotations or #annotations == 0 then
-		logger.dbg("Crossbill: No annotations in memory")
-		return nil
+	if not is_autosync then
+		UI.showSyncingMessage()
 	end
 
-	logger.dbg("Crossbill: Found", #annotations, "annotations in memory")
-	local results = {}
-
-	for _, annotation in ipairs(annotations) do
-		-- Only include highlights and notes, skip other annotation types
-		if annotation.text or annotation.note then
-			table.insert(results, {
-				text = annotation.text or "",
-				note = annotation.note or nil,
-				datetime = annotation.datetime or "",
-				page = annotation.pageno or annotation.page,
-				chapter = annotation.chapter or nil,
-			})
-		end
-	end
-
-	logger.dbg("Crossbill: Converted", #results, "annotations to highlights")
-	return results
-end
-
-function CrossbillSync:getHighlights(doc_path)
-	local doc_settings = DocSettings:open(doc_path)
-	local results = {}
-
-	-- Try modern annotations format first
-	local annotations = doc_settings:readSetting("annotations")
-	if annotations then
-		for _, annotation in ipairs(annotations) do
-			table.insert(results, {
-				text = annotation.text or "",
-				note = annotation.note or nil,
-				datetime = annotation.datetime or "",
-				page = annotation.pageno,
-				chapter = annotation.chapter or nil,
-			})
-		end
-		return results
-	end
-
-	-- Fallback to legacy format
-	local highlights = doc_settings:readSetting("highlight")
-	if not highlights then
-		return nil
-	end
-
-	local bookmarks = doc_settings:readSetting("bookmarks") or {}
-
-	for page, items in pairs(highlights) do
-		for _, item in ipairs(items) do
-			local note = nil
-
-			-- Find matching bookmark for note
-			for _, bookmark in pairs(bookmarks) do
-				if bookmark.datetime == item.datetime then
-					note = bookmark.text or nil
-					break
-				end
-			end
-
-			table.insert(results, {
-				text = item.text or "",
-				note = note,
-				datetime = item.datetime or "",
-				page = item.page,
-				chapter = item.chapter or nil,
-			})
-		end
-	end
-
-	return results
-end
-
-function CrossbillSync:getChapterNumberMap()
-	-- Extract table of contents (TOC) from the document
-	-- Returns a mapping from chapter name to chapter number for proper sorting
-	local chapter_map = {}
-
-	-- Get TOC from the document
-	-- self.ui.toc is the TOC controller which has the toc table
-	if self.ui.toc and self.ui.toc.toc then
-		local toc = self.ui.toc.toc
-
-		for i, item in ipairs(toc) do
-			-- Each TOC item has a title field
-			if item.title then
-				chapter_map[item.title] = i
-			end
-		end
-
-		logger.dbg("Crossbill: Created mapping for", #toc, "chapters from TOC")
-	else
-		logger.dbg("Crossbill: No TOC available for this document")
-	end
-
-	return chapter_map
-end
-
-function CrossbillSync:sendToServer(book_data, highlights, is_autosync)
-	-- Wrap everything in pcall for error handling
-	-- is_autosync: if true, don't show result popup (silent mode)
-	local success, result = pcall(function()
-		-- Get a valid auth token (will refresh or login as needed)
-		local token, auth_err = self:getValidToken()
-		if not token then
-			if not is_autosync then
-				UIManager:show(InfoMessage:new({
-					text = _("Authentication failed: ") .. (auth_err or "unknown error"),
-					timeout = 5,
-				}))
-			end
-			return false, auth_err
-		end
-
-		local payload = {
-			book = book_data,
-			highlights = highlights,
-		}
-
-		local body_json = JSON.encode(payload)
-
-		-- Construct full API URL from host
-		local api_url = self.settings.base_url .. "/api/v1/highlights/upload"
-		logger.dbg("Crossbill: Sending request to", api_url)
-		logger.dbg("Crossbill: Payload size:", #body_json, "bytes")
-
-		local response_body = {}
-
-		local request = {
-			url = api_url,
-			method = "POST",
-			headers = {
-				["Content-Type"] = "application/json",
-				["Accept"] = "application/json",
-				["Content-Length"] = tostring(#body_json),
-				["Authorization"] = "Bearer " .. token,
-			},
-			source = ltn12.source.string(body_json),
-			sink = ltn12.sink.table(response_body),
-		}
-
-		-- Use HTTP or HTTPS based on URL scheme
-		local code
-		if api_url:match("^https://") then
-			logger.dbg("Crossbill: Using HTTPS")
-			code = socket.skip(1, https.request(request))
-		else
-			logger.dbg("Crossbill: Using HTTP")
-			code = socket.skip(1, http.request(request))
-		end
-		socketutil:reset_timeout()
-
-		logger.dbg("Crossbill: Response code:", code)
-
-		if code == 200 then
-			local response_text = table.concat(response_body)
-			logger.dbg("Crossbill: Response:", response_text)
-
-			local ok, response_data = pcall(JSON.decode, response_text)
-			if not ok then
-				logger.err("Crossbill: Failed to decode JSON response:", response_text)
-				return false, "Invalid server response"
-			end
-
-			-- Upload cover image if available
-			if response_data.book_id then
-				self:uploadCoverImage(response_data.book_id, token)
-			end
-
-			-- Only show success popup for manual syncs
-			if not is_autosync then
-				UIManager:show(InfoMessage:new({
-					text = string.format(
-						_("Synced successfully!\n%d new, %d duplicates"),
-						response_data.highlights_created or 0,
-						response_data.highlights_skipped or 0
-					),
-					timeout = 3,
-				}))
-			end
-			return true
-		else
-			logger.err("Crossbill: Sync failed with code:", code)
-			-- Only show error popup for manual syncs
-			if not is_autosync then
-				UIManager:show(InfoMessage:new({
-					text = _("Sync failed: ") .. tostring(code or "unknown error"),
-					timeout = 3,
-				}))
-			end
-			return false, code
-		end
+	local success, err = pcall(function()
+		self:doSync(is_autosync)
 	end)
 
 	if not success then
-		logger.err("Crossbill: Exception during sync:", result)
-		-- Only show error popup for manual syncs
+		logger.err("Crossbill: Error in sync:", err)
 		if not is_autosync then
-			UIManager:show(InfoMessage:new({
-				text = _("Sync error: ") .. tostring(result),
-				timeout = 5,
-			}))
+			UI.showSyncError(err)
 		end
+	end
+
+	-- Always clean up WiFi after sync
+	Network.disableWifiIfNeeded()
+end
+
+--- Execute the sync workflow
+-- @param is_autosync boolean If true, run in silent mode
+function CrossbillSync:doSync(is_autosync)
+	-- Extract book metadata
+	local book_metadata = BookMetadata:new(self.ui)
+	local book_data = book_metadata:extractBookData()
+	local doc_path = book_metadata:getDocPath()
+
+	-- Extract highlights
+	local highlight_extractor = HighlightExtractor:new(self.ui)
+	local highlights = highlight_extractor:getHighlights(doc_path)
+
+	if not highlights or #highlights == 0 then
+		logger.dbg("Crossbill: No highlights to sync")
+		return
+	end
+
+	logger.dbg("Crossbill: Found", #highlights, "highlights")
+
+	-- Add chapter numbers to highlights
+	highlight_extractor:addChapterNumbers(highlights)
+
+	-- Upload highlights to server
+	local upload_success, response, err = self.api_client:uploadHighlights(book_data, highlights)
+
+	if not upload_success then
+		if not is_autosync then
+			if err and err:match("^Authentication") then
+				UI.showAuthError(err)
+			else
+				UI.showSyncFailed(err)
+			end
+		end
+		return
+	end
+
+	-- Upload cover image if available
+	if response and response.book_id then
+		self:uploadCoverImage(response.book_id, book_metadata)
+	end
+
+	-- Show success message for manual syncs
+	if not is_autosync then
+		UI.showSyncSuccess(response.highlights_created, response.highlights_skipped)
 	end
 end
 
-function CrossbillSync:getFilename(path)
-	return path:match("^.+/(.+)$") or path
-end
-
-function CrossbillSync:uploadCoverImage(book_id, token)
-	-- Extract and upload the book cover image
-	-- This function is called after successful highlights sync
+--- Upload cover image for a book
+-- @param book_id number The book ID from the server
+-- @param book_metadata BookMetadata instance
+function CrossbillSync:uploadCoverImage(book_id, book_metadata)
 	local success, err = pcall(function()
-		logger.dbg("Crossbill: Attempting to extract cover for book_id:", book_id)
+		local tmp_path, cover_data, cover_image = book_metadata:extractCoverToFile(book_id)
 
-		-- Get the cover image from the document
-		local cover_image = FileManagerBookInfo:getCoverImage(self.ui.document)
-
-		if not cover_image then
-			logger.dbg("Crossbill: No cover image available for this document")
+		if not cover_data then
 			return
 		end
 
-		logger.dbg("Crossbill: Cover image extracted, size:", cover_image:getWidth(), "x", cover_image:getHeight())
+		-- Upload cover
+		self.api_client:uploadCover(book_id, cover_data)
 
-		-- Save cover to temporary file
-		local tmp_cover_path = "/tmp/crossbill_cover_" .. book_id .. ".jpg"
-		cover_image:writeToFile(tmp_cover_path)
-		logger.dbg("Crossbill: Cover saved to temporary file:", tmp_cover_path)
-
-		-- Read the cover file content
-		local cover_file = io.open(tmp_cover_path, "rb")
-		if not cover_file then
-			logger.err("Crossbill: Failed to open temporary cover file")
+		-- Cleanup
+		if cover_image then
 			cover_image:free()
-			return
 		end
-
-		local cover_data = cover_file:read("*all")
-		cover_file:close()
-
-		-- Free the cover image from memory
-		cover_image:free()
-
-		-- Prepare multipart/form-data upload
-		local boundary = "----CrossbillBoundary" .. os.time()
-		local body_parts = {}
-
-		-- Add the file part
-		table.insert(body_parts, "--" .. boundary)
-		table.insert(body_parts, 'Content-Disposition: form-data; name="cover"; filename="cover.jpg"')
-		table.insert(body_parts, "Content-Type: image/jpeg")
-		table.insert(body_parts, "")
-		table.insert(body_parts, cover_data)
-		table.insert(body_parts, "--" .. boundary .. "--")
-
-		local body = table.concat(body_parts, "\r\n")
-
-		-- Construct API URL
-		local api_url = self.settings.base_url .. "/api/v1/books/" .. book_id .. "/metadata/cover"
-		logger.dbg("Crossbill: Uploading cover to", api_url)
-
-		local response_body = {}
-		local request = {
-			url = api_url,
-			method = "POST",
-			headers = {
-				["Content-Type"] = "multipart/form-data; boundary=" .. boundary,
-				["Content-Length"] = tostring(#body),
-				["Authorization"] = "Bearer " .. token,
-			},
-			source = ltn12.source.string(body),
-			sink = ltn12.sink.table(response_body),
-		}
-
-		-- Use HTTP or HTTPS based on URL scheme
-		local code
-		if api_url:match("^https://") then
-			code = socket.skip(1, https.request(request))
-		else
-			code = socket.skip(1, http.request(request))
-		end
-		socketutil:reset_timeout()
-
-		-- Clean up temporary file
-		os.remove(tmp_cover_path)
-
-		if code == 200 then
-			logger.info("Crossbill: Cover uploaded successfully for book", book_id)
-		else
-			logger.warn("Crossbill: Failed to upload cover, response code:", code)
+		if tmp_path then
+			os.remove(tmp_path)
 		end
 	end)
 
 	if not success then
 		logger.err("Crossbill: Error uploading cover:", err)
-		-- Don't show error to user, cover upload is optional
 	end
 end
 
-function CrossbillSync:registerEventHandlers()
-	-- Event handlers are automatically called by KOReader framework
-	-- when methods match the naming pattern on<EventName>
-	-- No explicit registration needed
-end
+-- Event handlers for auto-sync
 
+--- Called when document is closed
 function CrossbillSync:onCloseDocument()
 	-- Don't auto-sync on document close to avoid nil document errors
-	-- when switching between books (especially on Pocketbook)
-	return false -- Allow other handlers to process this event
+	return false
 end
 
+--- Called when device goes to sleep/suspend
 function CrossbillSync:onSuspend()
-	-- Called when device goes to sleep/suspend (user stops reading)
-	if self.settings.autosync_enabled then
+	if self.settings:isAutosyncEnabled() then
 		logger.info("Crossbill: Auto-syncing on suspend")
-		self:syncCurrentBook(true) -- true = autosync (silent mode)
+		self:syncCurrentBook(true)
 	end
-	return false -- Allow other handlers to process this event
+	return false
 end
 
+--- Called when KOReader exits
 function CrossbillSync:onExit()
-	-- Called when KOReader exits
-	if self.settings.autosync_enabled then
+	if self.settings:isAutosyncEnabled() then
 		logger.info("Crossbill: Auto-syncing on exit")
-		self:syncCurrentBook(true) -- true = autosync (silent mode)
+		self:syncCurrentBook(true)
 	end
-	return false -- Allow other handlers to process this event
+	return false
 end
 
 return CrossbillSync

--- a/clients/koreader-plugin/crossbill.koplugin/modules/api_client.lua
+++ b/clients/koreader-plugin/crossbill.koplugin/modules/api_client.lua
@@ -1,0 +1,106 @@
+--[[
+API Client Module for Crossbill Sync
+
+Provides a clean interface for communicating with the Crossbill server API.
+Handles highlight uploads, cover image uploads, and other API operations.
+]]
+
+local Network = require("modules/network")
+local logger = require("logger")
+
+local ApiClient = {}
+ApiClient.__index = ApiClient
+
+--- Create a new ApiClient instance
+-- @param settings Settings instance
+-- @param auth Auth instance
+-- @return ApiClient instance
+function ApiClient:new(settings, auth)
+	local instance = setmetatable({}, ApiClient)
+	instance.settings = settings
+	instance.auth = auth
+	return instance
+end
+
+--- Get the API base URL
+-- @return string API base URL
+function ApiClient:getApiUrl()
+	return self.settings:getBaseUrl() .. "/api/v1"
+end
+
+--- Upload highlights to the server
+-- @param book_data table Book metadata
+-- @param highlights table Array of highlights
+-- @return boolean Success status
+-- @return table|nil Response data containing book_id, highlights_created, highlights_skipped
+-- @return string|nil Error message
+function ApiClient:uploadHighlights(book_data, highlights)
+	local token, auth_err = self.auth:getValidToken()
+	if not token then
+		return false, nil, auth_err or "Authentication failed"
+	end
+
+	local payload = {
+		book = book_data,
+		highlights = highlights,
+	}
+
+	local api_url = self:getApiUrl() .. "/highlights/upload"
+	logger.dbg("Crossbill API: Sending highlights to", api_url)
+
+	local code, response_data, err = Network.postJson(api_url, payload, token)
+
+	if not code then
+		logger.err("Crossbill API: Network error:", err)
+		return false, nil, err or "Network error"
+	end
+
+	if code == 200 and response_data then
+		logger.dbg("Crossbill API: Highlights uploaded successfully")
+		return true, response_data, nil
+	else
+		logger.err("Crossbill API: Upload failed with code:", code)
+		return false, nil, "Upload failed: " .. tostring(code)
+	end
+end
+
+--- Upload a cover image for a book
+-- @param book_id number The book ID
+-- @param cover_data string The cover image binary data
+-- @return boolean Success status
+-- @return string|nil Error message
+function ApiClient:uploadCover(book_id, cover_data)
+	local token, auth_err = self.auth:getValidToken()
+	if not token then
+		return false, auth_err or "Authentication failed"
+	end
+
+	local api_url = self:getApiUrl() .. "/books/" .. book_id .. "/metadata/cover"
+	logger.dbg("Crossbill API: Uploading cover to", api_url)
+
+	local files = {
+		{
+			name = "cover",
+			filename = "cover.jpg",
+			content_type = "image/jpeg",
+			data = cover_data,
+		},
+	}
+
+	local code, _, err = Network.postMultipart(api_url, files, token)
+
+	if not code then
+		logger.err("Crossbill API: Network error uploading cover:", err)
+		return false, err or "Network error"
+	end
+
+	if code == 200 then
+		logger.info("Crossbill API: Cover uploaded successfully for book", book_id)
+		return true, nil
+	else
+		logger.warn("Crossbill API: Cover upload failed with code:", code)
+		return false, "Upload failed: " .. tostring(code)
+	end
+end
+
+return ApiClient

--- a/clients/koreader-plugin/crossbill.koplugin/modules/auth.lua
+++ b/clients/koreader-plugin/crossbill.koplugin/modules/auth.lua
@@ -1,0 +1,135 @@
+--[[
+Authentication Module for Crossbill Sync
+
+Handles user authentication with the Crossbill server including:
+- Initial login with username/password
+- Token refresh using refresh tokens
+- Token validation and caching
+]]
+
+local Network = require("modules/network")
+local logger = require("logger")
+
+local Auth = {}
+Auth.__index = Auth
+
+-- Buffer time before token expiry (in seconds) to trigger refresh
+local TOKEN_EXPIRY_BUFFER = 60
+
+--- Create a new Auth instance
+-- @param settings Settings instance
+-- @return Auth instance
+function Auth:new(settings)
+	local instance = setmetatable({}, Auth)
+	instance.settings = settings
+	return instance
+end
+
+--- Authenticate with username and password
+-- @return string|nil Access token on success
+-- @return string|nil Error message on failure
+function Auth:login()
+	local username = self.settings:getUsername()
+	local password = self.settings:getPassword()
+
+	if username == "" or password == "" then
+		logger.warn("Crossbill Auth: Username or password not configured")
+		return nil, "Username or password not configured"
+	end
+
+	local base_url = self.settings:getBaseUrl()
+	local api_url = base_url .. "/api/v1/auth/login"
+	logger.dbg("Crossbill Auth: Logging in to", api_url)
+
+	local code, response_data, err = Network.postForm(api_url, {
+		username = username,
+		password = password,
+	})
+
+	if not code then
+		logger.err("Crossbill Auth: Network error during login:", err)
+		return nil, err or "Network error"
+	end
+
+	if code == 200 and response_data and response_data.access_token then
+		logger.dbg("Crossbill Auth: Login successful")
+		self.settings:setTokens(response_data.access_token, response_data.refresh_token, response_data.expires_in)
+		return response_data.access_token
+	else
+		logger.err("Crossbill Auth: Login failed with code:", code)
+		return nil, "Login failed: " .. tostring(code)
+	end
+end
+
+--- Refresh the access token using stored refresh token
+-- @return string|nil New access token on success
+-- @return string|nil Error message on failure
+function Auth:refreshToken()
+	local refresh_token = self.settings:getRefreshToken()
+	if not refresh_token then
+		logger.dbg("Crossbill Auth: No refresh token available")
+		return nil, "No refresh token"
+	end
+
+	local base_url = self.settings:getBaseUrl()
+	local api_url = base_url .. "/api/v1/auth/refresh"
+	logger.dbg("Crossbill Auth: Refreshing token at", api_url)
+
+	local code, response_data, err = Network.postJson(api_url, {
+		refresh_token = refresh_token,
+	})
+
+	if not code then
+		logger.err("Crossbill Auth: Network error during refresh:", err)
+		return nil, err or "Network error"
+	end
+
+	if code == 200 and response_data and response_data.access_token then
+		logger.dbg("Crossbill Auth: Token refresh successful")
+		self.settings:setTokens(response_data.access_token, response_data.refresh_token, response_data.expires_in)
+		return response_data.access_token
+	else
+		logger.err("Crossbill Auth: Token refresh failed with code:", code)
+		-- Clear stored tokens on refresh failure
+		self.settings:clearTokens()
+		return nil, "Refresh failed: " .. tostring(code)
+	end
+end
+
+--- Get a valid access token, refreshing or logging in as needed
+-- @return string|nil Access token on success
+-- @return string|nil Error message on failure
+function Auth:getValidToken()
+	local current_time = os.time()
+	local expires_at = self.settings:getTokenExpiresAt()
+	local access_token = self.settings:getAccessToken()
+
+	-- Check if we have a cached token that's still valid (with buffer)
+	if access_token and expires_at and (expires_at - TOKEN_EXPIRY_BUFFER) > current_time then
+		logger.dbg("Crossbill Auth: Using cached access token")
+		return access_token
+	end
+
+	-- Try to refresh the token if we have a refresh token
+	local refresh_token = self.settings:getRefreshToken()
+	if refresh_token then
+		logger.dbg("Crossbill Auth: Access token expired or missing, trying refresh")
+		local token, err = self:refreshToken()
+		if token then
+			return token
+		end
+		logger.dbg("Crossbill Auth: Refresh failed:", err)
+	end
+
+	-- Fall back to full login
+	logger.dbg("Crossbill Auth: Falling back to full login")
+	return self:login()
+end
+
+--- Check if authentication is configured
+-- @return boolean True if credentials are available
+function Auth:isConfigured()
+	return self.settings:hasCredentials()
+end
+
+return Auth

--- a/clients/koreader-plugin/crossbill.koplugin/modules/book_metadata.lua
+++ b/clients/koreader-plugin/crossbill.koplugin/modules/book_metadata.lua
@@ -1,0 +1,202 @@
+--[[
+Book Metadata Module for Crossbill Sync
+
+Extracts book metadata from KOReader documents including:
+- Title, author, description
+- ISBN from identifiers
+- Language, page count
+- Keywords/tags
+- Cover image
+]]
+
+local DocSettings = require("docsettings")
+local FileManagerBookInfo = require("apps/filemanager/filemanagerbookinfo")
+local logger = require("logger")
+
+local BookMetadata = {}
+BookMetadata.__index = BookMetadata
+
+--- Create a new BookMetadata instance
+-- @param ui table The KOReader UI context (self.ui from plugin)
+-- @return BookMetadata instance
+function BookMetadata:new(ui)
+	local instance = setmetatable({}, BookMetadata)
+	instance.ui = ui
+	return instance
+end
+
+--- Extract filename from a file path
+-- @param path string Full file path
+-- @return string Filename only
+local function getFilename(path)
+	return path:match("^.+/(.+)$") or path
+end
+
+--- Extract ISBN from identifiers string
+-- The format can vary: "ISBN:9780735211292\nAMAZON:..." or "ISBN:9780735211292 AMAZON:..."
+-- @param identifiers string The identifiers string
+-- @return string|nil ISBN if found
+local function extractISBN(identifiers)
+	if not identifiers then
+		return nil
+	end
+
+	-- Match ISBN: followed by digits/hyphens/X until we hit a non-ISBN character
+	local isbn = identifiers:match("ISBN:([%d%-xX]+)")
+	if isbn then
+		logger.dbg("Crossbill Metadata: Extracted ISBN:", isbn)
+	else
+		logger.dbg("Crossbill Metadata: No ISBN found in identifiers:", identifiers)
+	end
+	return isbn
+end
+
+--- Parse keywords string into array
+-- Keywords are separated by newlines
+-- @param keywords_str string The keywords string
+-- @return table|nil Array of keywords
+local function parseKeywords(keywords_str)
+	if not keywords_str then
+		return nil
+	end
+
+	local keywords = {}
+	for keyword in keywords_str:gmatch("[^\n]+") do
+		local trimmed = keyword:match("^%s*(.-)%s*$")
+		if trimmed and trimmed ~= "" then
+			table.insert(keywords, trimmed)
+		end
+	end
+
+	if #keywords > 0 then
+		logger.dbg("Crossbill Metadata: Extracted", #keywords, "keywords")
+		return keywords
+	end
+	return nil
+end
+
+--- Get document settings for metadata
+-- @param doc_path string Path to the document
+-- @return table Combined metadata from doc_props and doc_settings
+function BookMetadata:getDocMetadata(doc_path)
+	local doc_settings = DocSettings:open(doc_path)
+	local book_props = self.ui.doc_props
+
+	-- Merge doc_settings metadata with live doc_props
+	local metadata_props = doc_settings:readSetting("doc_props") or book_props
+
+	return {
+		book_props = book_props,
+		metadata_props = metadata_props,
+		doc_settings = doc_settings,
+	}
+end
+
+--- Extract complete book metadata
+-- @return table Book data ready for API upload
+function BookMetadata:extractBookData()
+	local doc_path = self.ui.document.file
+	local meta = self:getDocMetadata(doc_path)
+
+	local book_props = meta.book_props
+	local metadata_props = meta.metadata_props
+	local doc_settings = meta.doc_settings
+
+	-- Extract ISBN from identifiers
+	local isbn = extractISBN(metadata_props.identifiers)
+
+	-- Extract language
+	local language = metadata_props.language or nil
+	if language then
+		logger.dbg("Crossbill Metadata: Extracted language:", language)
+	end
+
+	-- Extract page count
+	local page_count = doc_settings:readSetting("doc_pages") or nil
+	if page_count then
+		logger.dbg("Crossbill Metadata: Extracted page count:", page_count)
+	end
+
+	-- Parse keywords into array
+	local keywords = parseKeywords(metadata_props.keywords)
+
+	-- Build book data
+	local title = book_props.display_title or book_props.title or getFilename(doc_path)
+	logger.dbg("Crossbill Metadata: Syncing book:", title)
+
+	return {
+		title = title,
+		author = book_props.authors or nil,
+		isbn = isbn,
+		description = metadata_props.description or nil,
+		language = language,
+		page_count = page_count,
+		keywords = keywords,
+	}
+end
+
+--- Extract cover image from document
+-- @return userdata|nil Cover image object (must be freed after use)
+function BookMetadata:extractCover()
+	if not self.ui.document then
+		logger.dbg("Crossbill Metadata: No document available for cover extraction")
+		return nil
+	end
+
+	local cover_image = FileManagerBookInfo:getCoverImage(self.ui.document)
+	if cover_image then
+		logger.dbg(
+			"Crossbill Metadata: Cover image extracted, size:",
+			cover_image:getWidth(),
+			"x",
+			cover_image:getHeight()
+		)
+	else
+		logger.dbg("Crossbill Metadata: No cover image available for this document")
+	end
+
+	return cover_image
+end
+
+--- Save cover image to temporary file and return path and data
+-- Caller is responsible for cleaning up the temp file and freeing the image
+-- @return string|nil Temporary file path
+-- @return string|nil Cover image data
+-- @return userdata|nil Cover image object (caller must free)
+function BookMetadata:extractCoverToFile(book_id)
+	local cover_image = self:extractCover()
+	if not cover_image then
+		return nil, nil, nil
+	end
+
+	local tmp_path = "/tmp/crossbill_cover_" .. book_id .. ".jpg"
+	cover_image:writeToFile(tmp_path)
+	logger.dbg("Crossbill Metadata: Cover saved to temporary file:", tmp_path)
+
+	-- Read the file content
+	local cover_file = io.open(tmp_path, "rb")
+	if not cover_file then
+		logger.err("Crossbill Metadata: Failed to open temporary cover file")
+		cover_image:free()
+		return nil, nil, nil
+	end
+
+	local cover_data = cover_file:read("*all")
+	cover_file:close()
+
+	return tmp_path, cover_data, cover_image
+end
+
+--- Get document path
+-- @return string Document file path
+function BookMetadata:getDocPath()
+	return self.ui.document.file
+end
+
+--- Check if document is available
+-- @return boolean True if document is loaded
+function BookMetadata:hasDocument()
+	return self.ui.document ~= nil
+end
+
+return BookMetadata

--- a/clients/koreader-plugin/crossbill.koplugin/modules/highlight_extractor.lua
+++ b/clients/koreader-plugin/crossbill.koplugin/modules/highlight_extractor.lua
@@ -1,0 +1,165 @@
+--[[
+Highlight Extractor Module for Crossbill Sync
+
+Extracts highlights from KOReader documents.
+Supports both modern annotations format and legacy highlight format.
+Also handles chapter number mapping from table of contents.
+]]
+
+local DocSettings = require("docsettings")
+local logger = require("logger")
+
+local HighlightExtractor = {}
+HighlightExtractor.__index = HighlightExtractor
+
+--- Create a new HighlightExtractor instance
+-- @param ui table The KOReader UI context (self.ui from plugin)
+-- @return HighlightExtractor instance
+function HighlightExtractor:new(ui)
+	local instance = setmetatable({}, HighlightExtractor)
+	instance.ui = ui
+	return instance
+end
+
+--- Convert a raw annotation to our standard highlight format
+-- @param annotation table The raw annotation object
+-- @return table Formatted highlight object
+local function formatHighlight(annotation)
+	return {
+		text = annotation.text or "",
+		note = annotation.note or nil,
+		datetime = annotation.datetime or "",
+		page = annotation.pageno or annotation.page,
+		chapter = annotation.chapter or nil,
+	}
+end
+
+--- Get highlights directly from ReaderAnnotation's memory
+-- This is preferred as it captures annotations not yet flushed to disk
+-- @return table|nil Array of highlights, or nil if not available
+function HighlightExtractor:getHighlightsFromMemory()
+	if not self.ui.annotation then
+		logger.dbg("Crossbill Extractor: ReaderAnnotation module not available")
+		return nil
+	end
+
+	local annotations = self.ui.annotation.annotations
+	if not annotations or #annotations == 0 then
+		logger.dbg("Crossbill Extractor: No annotations in memory")
+		return nil
+	end
+
+	logger.dbg("Crossbill Extractor: Found", #annotations, "annotations in memory")
+	local results = {}
+
+	for _, annotation in ipairs(annotations) do
+		-- Only include highlights and notes, skip other annotation types
+		if annotation.text or annotation.note then
+			table.insert(results, formatHighlight(annotation))
+		end
+	end
+
+	logger.dbg("Crossbill Extractor: Converted", #results, "annotations to highlights")
+	return results
+end
+
+--- Get highlights from document settings file (disk)
+-- Supports both modern annotations format and legacy highlight format
+-- @param doc_path string Path to the document
+-- @return table|nil Array of highlights, or nil if none found
+function HighlightExtractor:getHighlightsFromDisk(doc_path)
+	local doc_settings = DocSettings:open(doc_path)
+	local results = {}
+
+	-- Try modern annotations format first
+	local annotations = doc_settings:readSetting("annotations")
+	if annotations then
+		for _, annotation in ipairs(annotations) do
+			table.insert(results, formatHighlight(annotation))
+		end
+		logger.dbg("Crossbill Extractor: Found", #results, "highlights in modern format")
+		return results
+	end
+
+	-- Fallback to legacy highlight format
+	local highlights = doc_settings:readSetting("highlight")
+	if not highlights then
+		logger.dbg("Crossbill Extractor: No highlights found in settings")
+		return nil
+	end
+
+	local bookmarks = doc_settings:readSetting("bookmarks") or {}
+
+	for _, items in pairs(highlights) do
+		for _, item in ipairs(items) do
+			local note = nil
+
+			-- Find matching bookmark for note (in legacy format, notes are in bookmarks)
+			for _, bookmark in pairs(bookmarks) do
+				if bookmark.datetime == item.datetime then
+					note = bookmark.text or nil
+					break
+				end
+			end
+
+			table.insert(results, {
+				text = item.text or "",
+				note = note,
+				datetime = item.datetime or "",
+				page = item.page,
+				chapter = item.chapter or nil,
+			})
+		end
+	end
+
+	logger.dbg("Crossbill Extractor: Found", #results, "highlights in legacy format")
+	return results
+end
+
+--- Get all highlights, trying memory first then falling back to disk
+-- @param doc_path string Path to the document
+-- @return table|nil Array of highlights
+function HighlightExtractor:getHighlights(doc_path)
+	return self:getHighlightsFromMemory() or self:getHighlightsFromDisk(doc_path)
+end
+
+--- Get chapter number mapping from table of contents
+-- Maps chapter names to their order number for proper sorting
+-- @return table Map of chapter name -> chapter number
+function HighlightExtractor:getChapterNumberMap()
+	local chapter_map = {}
+
+	-- Get TOC from the document
+	if self.ui.toc and self.ui.toc.toc then
+		local toc = self.ui.toc.toc
+
+		for i, item in ipairs(toc) do
+			if item.title then
+				chapter_map[item.title] = i
+			end
+		end
+
+		logger.dbg("Crossbill Extractor: Created mapping for", #toc, "chapters from TOC")
+	else
+		logger.dbg("Crossbill Extractor: No TOC available for this document")
+	end
+
+	return chapter_map
+end
+
+--- Add chapter numbers to highlights based on chapter names
+-- @param highlights table Array of highlights to augment
+-- @return table The same highlights array with chapter_number added
+function HighlightExtractor:addChapterNumbers(highlights)
+	local chapter_map = self:getChapterNumberMap()
+
+	for _, highlight in ipairs(highlights) do
+		if highlight.chapter and chapter_map[highlight.chapter] then
+			highlight.chapter_number = chapter_map[highlight.chapter]
+		end
+	end
+
+	return highlights
+end
+
+return HighlightExtractor

--- a/clients/koreader-plugin/crossbill.koplugin/modules/network.lua
+++ b/clients/koreader-plugin/crossbill.koplugin/modules/network.lua
@@ -1,0 +1,252 @@
+--[[
+Network Module for Crossbill Sync
+
+Provides HTTP/HTTPS request utilities and WiFi management.
+Abstracts away the complexity of KOReader's networking layer.
+]]
+
+local socket = require("socket")
+local http = require("socket.http")
+local https = require("ssl.https")
+local ltn12 = require("ltn12")
+local socketutil = require("socketutil")
+local NetworkMgr = require("ui/network/manager")
+local logger = require("logger")
+
+local Network = {}
+
+-- Track whether we enabled WiFi (so we can turn it off after sync)
+local wifi_enabled_by_us = false
+
+--- URL encode a string for use in form-urlencoded data
+-- @param str string The string to encode
+-- @return string The URL-encoded string
+function Network.urlEncode(str)
+	if str then
+		str = string.gsub(str, "\n", "\r\n")
+		str = string.gsub(str, "([^%w _%%%-%.~])", function(c)
+			return string.format("%%%02X", string.byte(c))
+		end)
+		str = string.gsub(str, " ", "+")
+	end
+	return str
+end
+
+--- Make an HTTP/HTTPS request
+-- @param options table Request options
+--   - url: string (required) The URL to request
+--   - method: string (default "GET") HTTP method
+--   - headers: table HTTP headers
+--   - body: string Request body
+-- @return number|nil HTTP status code
+-- @return string Response body
+-- @return string|nil Error message
+function Network.request(options)
+	local url = options.url
+	local method = options.method or "GET"
+	local headers = options.headers or {}
+	local body = options.body
+
+	-- Set content length header if body is provided
+	if body and not headers["Content-Length"] then
+		headers["Content-Length"] = tostring(#body)
+	end
+
+	local response_body = {}
+	local request = {
+		url = url,
+		method = method,
+		headers = headers,
+		sink = ltn12.sink.table(response_body),
+	}
+
+	if body then
+		request.source = ltn12.source.string(body)
+	end
+
+	-- Use HTTP or HTTPS based on URL scheme
+	local code, status_or_err
+	if url:match("^https://") then
+		logger.dbg("Crossbill Network: Using HTTPS for", url)
+		code, status_or_err = socket.skip(1, https.request(request))
+	else
+		logger.dbg("Crossbill Network: Using HTTP for", url)
+		code, status_or_err = socket.skip(1, http.request(request))
+	end
+
+	-- Reset socket timeout
+	socketutil:reset_timeout()
+
+	local response_text = table.concat(response_body)
+	logger.dbg("Crossbill Network: Response code:", code)
+
+	if code then
+		return code, response_text, nil
+	else
+		return nil, "", status_or_err or "Unknown network error"
+	end
+end
+
+--- Make a JSON POST request
+-- @param url string The URL to request
+-- @param data table The data to JSON-encode and send
+-- @param token string|nil Bearer token for authorization
+-- @return number|nil HTTP status code
+-- @return table|nil Parsed JSON response
+-- @return string|nil Error message
+function Network.postJson(url, data, token)
+	local JSON = require("json")
+	local body = JSON.encode(data)
+
+	local headers = {
+		["Content-Type"] = "application/json",
+		["Accept"] = "application/json",
+	}
+
+	if token then
+		headers["Authorization"] = "Bearer " .. token
+	end
+
+	local code, response_text, err = Network.request({
+		url = url,
+		method = "POST",
+		headers = headers,
+		body = body,
+	})
+
+	if not code then
+		return nil, nil, err
+	end
+
+	if response_text and response_text ~= "" then
+		local ok, response_data = pcall(JSON.decode, response_text)
+		if ok then
+			return code, response_data, nil
+		else
+			return code, nil, "Invalid JSON response"
+		end
+	end
+
+	return code, nil, nil
+end
+
+--- Make a form-urlencoded POST request
+-- @param url string The URL to request
+-- @param data table Key-value pairs to encode
+-- @return number|nil HTTP status code
+-- @return table|nil Parsed JSON response
+-- @return string|nil Error message
+function Network.postForm(url, data)
+	local JSON = require("json")
+
+	-- Build form-urlencoded body
+	local parts = {}
+	for key, value in pairs(data) do
+		table.insert(parts, Network.urlEncode(key) .. "=" .. Network.urlEncode(value))
+	end
+	local body = table.concat(parts, "&")
+
+	local headers = {
+		["Content-Type"] = "application/x-www-form-urlencoded",
+		["Accept"] = "application/json",
+	}
+
+	local code, response_text, err = Network.request({
+		url = url,
+		method = "POST",
+		headers = headers,
+		body = body,
+	})
+
+	if not code then
+		return nil, nil, err
+	end
+
+	if response_text and response_text ~= "" then
+		local ok, response_data = pcall(JSON.decode, response_text)
+		if ok then
+			return code, response_data, nil
+		else
+			return code, nil, "Invalid JSON response"
+		end
+	end
+
+	return code, nil, nil
+end
+
+--- Make a multipart/form-data POST request
+-- @param url string The URL to request
+-- @param files table Array of file objects {name, filename, content_type, data}
+-- @param token string|nil Bearer token for authorization
+-- @return number|nil HTTP status code
+-- @return string Response body
+-- @return string|nil Error message
+function Network.postMultipart(url, files, token)
+	local boundary = "----CrossbillBoundary" .. os.time()
+	local body_parts = {}
+
+	for _, file in ipairs(files) do
+		table.insert(body_parts, "--" .. boundary)
+		table.insert(
+			body_parts,
+			string.format('Content-Disposition: form-data; name="%s"; filename="%s"', file.name, file.filename)
+		)
+		table.insert(body_parts, "Content-Type: " .. file.content_type)
+		table.insert(body_parts, "")
+		table.insert(body_parts, file.data)
+	end
+	table.insert(body_parts, "--" .. boundary .. "--")
+
+	local body = table.concat(body_parts, "\r\n")
+
+	local headers = {
+		["Content-Type"] = "multipart/form-data; boundary=" .. boundary,
+	}
+
+	if token then
+		headers["Authorization"] = "Bearer " .. token
+	end
+
+	return Network.request({
+		url = url,
+		method = "POST",
+		headers = headers,
+		body = body,
+	})
+end
+
+--- Ensure WiFi is enabled, calling callback when ready
+-- @param callback function Function to call when network is available
+-- @return boolean True if already online, false if waiting for connection
+function Network.ensureWifiEnabled(callback)
+	if NetworkMgr:willRerunWhenOnline(callback) then
+		-- Network is off, NetworkMgr will call callback when online
+		logger.info("Crossbill Network: WiFi is off, prompting to enable...")
+		wifi_enabled_by_us = true
+		return false
+	else
+		-- Network is already on
+		logger.info("Crossbill Network: WiFi already enabled")
+		wifi_enabled_by_us = false
+		return true
+	end
+end
+
+--- Disable WiFi if we enabled it for the sync
+function Network.disableWifiIfNeeded()
+	if wifi_enabled_by_us then
+		logger.info("Crossbill Network: Disabling WiFi after sync")
+		NetworkMgr:turnOffWifi()
+		wifi_enabled_by_us = false
+	else
+		logger.info("Crossbill Network: WiFi was already on, leaving it enabled")
+	end
+end
+
+--- Check if we enabled WiFi
+-- @return boolean True if we enabled WiFi
+function Network.didWeEnableWifi()
+	return wifi_enabled_by_us
+end
+
+return Network

--- a/clients/koreader-plugin/crossbill.koplugin/modules/settings.lua
+++ b/clients/koreader-plugin/crossbill.koplugin/modules/settings.lua
@@ -1,0 +1,198 @@
+--[[
+Settings Module for Crossbill Sync
+
+Manages plugin configuration including server URL, credentials, and tokens.
+Provides a clean API for loading, saving, and accessing settings.
+]]
+
+local logger = require("logger")
+
+local Settings = {}
+Settings.__index = Settings
+
+-- Default settings values
+local DEFAULTS = {
+	base_url = "http://localhost:8000",
+	username = "",
+	password = "",
+	autosync_enabled = false,
+	access_token = nil,
+	refresh_token = nil,
+	token_expires_at = nil,
+}
+
+-- Settings key in KOReader's global settings
+local SETTINGS_KEY = "crossbill_sync"
+
+--- Create a new Settings instance
+-- @return Settings instance
+function Settings:new()
+	local instance = setmetatable({}, Settings)
+	instance._data = nil
+	return instance
+end
+
+--- Load settings from KOReader's global settings
+-- @return self for chaining
+function Settings:load()
+	self._data = G_reader_settings:readSetting(SETTINGS_KEY) or {}
+	-- Apply defaults for any missing keys
+	for key, value in pairs(DEFAULTS) do
+		if self._data[key] == nil then
+			self._data[key] = value
+		end
+	end
+	logger.dbg("Crossbill Settings: Loaded settings")
+	return self
+end
+
+--- Save settings to KOReader's global settings
+-- @return self for chaining
+function Settings:save()
+	G_reader_settings:saveSetting(SETTINGS_KEY, self._data)
+	logger.dbg("Crossbill Settings: Saved settings")
+	return self
+end
+
+--- Get a setting value
+-- @param key string The setting key
+-- @return mixed The setting value
+function Settings:get(key)
+	if self._data == nil then
+		self:load()
+	end
+	return self._data[key]
+end
+
+--- Set a setting value
+-- @param key string The setting key
+-- @param value mixed The setting value
+-- @return self for chaining
+function Settings:set(key, value)
+	if self._data == nil then
+		self:load()
+	end
+	self._data[key] = value
+	return self
+end
+
+--- Get the base URL
+-- @return string The server base URL
+function Settings:getBaseUrl()
+	return self:get("base_url")
+end
+
+--- Set the base URL (normalizes by removing trailing slash)
+-- @param url string The server base URL
+-- @return self for chaining
+function Settings:setBaseUrl(url)
+	-- Remove trailing slash if present
+	local normalized = url:gsub("/$", "")
+	return self:set("base_url", normalized)
+end
+
+--- Get the username
+-- @return string The username
+function Settings:getUsername()
+	return self:get("username") or ""
+end
+
+--- Set the username
+-- @param username string The username
+-- @return self for chaining
+function Settings:setUsername(username)
+	return self:set("username", username)
+end
+
+--- Get the password
+-- @return string The password
+function Settings:getPassword()
+	return self:get("password") or ""
+end
+
+--- Set the password
+-- @param password string The password
+-- @return self for chaining
+function Settings:setPassword(password)
+	return self:set("password", password)
+end
+
+--- Check if autosync is enabled
+-- @return boolean True if autosync is enabled
+function Settings:isAutosyncEnabled()
+	return self:get("autosync_enabled") == true
+end
+
+--- Toggle autosync setting
+-- @return boolean The new autosync state
+function Settings:toggleAutosync()
+	local new_state = not self:isAutosyncEnabled()
+	self:set("autosync_enabled", new_state)
+	self:save()
+	return new_state
+end
+
+--- Get the cached access token
+-- @return string|nil The access token
+function Settings:getAccessToken()
+	return self:get("access_token")
+end
+
+--- Get the cached refresh token
+-- @return string|nil The refresh token
+function Settings:getRefreshToken()
+	return self:get("refresh_token")
+end
+
+--- Get the token expiration timestamp
+-- @return number|nil Unix timestamp when token expires
+function Settings:getTokenExpiresAt()
+	return self:get("token_expires_at")
+end
+
+--- Store authentication tokens
+-- @param access_token string The access token
+-- @param refresh_token string|nil The refresh token
+-- @param expires_in number|nil Seconds until token expires
+-- @return self for chaining
+function Settings:setTokens(access_token, refresh_token, expires_in)
+	self:set("access_token", access_token)
+	if refresh_token then
+		self:set("refresh_token", refresh_token)
+	end
+	if expires_in then
+		self:set("token_expires_at", os.time() + expires_in)
+	end
+	return self:save()
+end
+
+--- Clear all authentication tokens
+-- @return self for chaining
+function Settings:clearTokens()
+	self:set("access_token", nil)
+	self:set("refresh_token", nil)
+	self:set("token_expires_at", nil)
+	return self:save()
+end
+
+--- Check if credentials are configured
+-- @return boolean True if username and password are set
+function Settings:hasCredentials()
+	local username = self:getUsername()
+	local password = self:getPassword()
+	return username ~= "" and password ~= ""
+end
+
+--- Update server configuration
+-- @param base_url string The server URL
+-- @param username string The username
+-- @param password string The password
+-- @return self for chaining
+function Settings:updateServerConfig(base_url, username, password)
+	self:setBaseUrl(base_url)
+	self:setUsername(username)
+	self:setPassword(password)
+	return self:save()
+end
+
+return Settings

--- a/clients/koreader-plugin/crossbill.koplugin/modules/ui.lua
+++ b/clients/koreader-plugin/crossbill.koplugin/modules/ui.lua
@@ -1,0 +1,153 @@
+--[[
+UI Module for Crossbill Sync
+
+Provides UI components for the plugin including:
+- Information messages and notifications
+- Server configuration dialog
+- Menu structure
+]]
+
+local UIManager = require("ui/uimanager")
+local InfoMessage = require("ui/widget/infomessage")
+local MultiInputDialog = require("ui/widget/multiinputdialog")
+local _ = require("gettext")
+
+local UI = {}
+
+--- Show an informational message to the user
+-- @param text string The message to display
+-- @param timeout number|nil Auto-dismiss timeout in seconds (nil = no auto-dismiss)
+function UI.showMessage(text, timeout)
+	UIManager:show(InfoMessage:new({
+		text = text,
+		timeout = timeout,
+	}))
+end
+
+--- Show a syncing in progress message
+function UI.showSyncingMessage()
+	UI.showMessage(_("Syncing highlights..."), 2)
+end
+
+--- Show sync success message
+-- @param created number Number of new highlights
+-- @param skipped number Number of duplicate highlights
+function UI.showSyncSuccess(created, skipped)
+	UI.showMessage(string.format(_("Synced successfully!\n%d new, %d duplicates"), created or 0, skipped or 0), 3)
+end
+
+--- Show sync error message
+-- @param error_msg string The error message
+function UI.showSyncError(error_msg)
+	UI.showMessage(_("Sync error: ") .. tostring(error_msg), 5)
+end
+
+--- Show sync failed message
+-- @param code number|string The error code
+function UI.showSyncFailed(code)
+	UI.showMessage(_("Sync failed: ") .. tostring(code or "unknown error"), 3)
+end
+
+--- Show authentication error message
+-- @param error_msg string The error message
+function UI.showAuthError(error_msg)
+	UI.showMessage(_("Authentication failed: ") .. (error_msg or "unknown error"), 5)
+end
+
+--- Show settings saved message
+function UI.showSettingsSaved()
+	UI.showMessage(_("Settings saved"))
+end
+
+--- Show autosync status change message
+-- @param enabled boolean Whether autosync is now enabled
+function UI.showAutosyncToggled(enabled)
+	UI.showMessage(enabled and _("Auto-sync enabled") or _("Auto-sync disabled"))
+end
+
+--- Show server configuration dialog
+-- @param settings Settings instance
+-- @param on_save function Callback when settings are saved
+function UI.showConfigureServerDialog(settings, on_save)
+	local dialog
+	dialog = MultiInputDialog:new({
+		title = _("Crossbill Settings"),
+		fields = {
+			{
+				text = settings:getBaseUrl() or "",
+				hint = _("Server URL (e.g., https://example.com)"),
+			},
+			{
+				text = settings:getUsername() or "",
+				hint = _("Username"),
+			},
+			{
+				text = settings:getPassword() or "",
+				hint = _("Password"),
+				text_type = "password",
+			},
+		},
+		buttons = {
+			{
+				{
+					text = _("Cancel"),
+					callback = function()
+						UIManager:close(dialog)
+					end,
+				},
+				{
+					text = _("Save"),
+					is_enter_default = true,
+					callback = function()
+						local fields = dialog:getFields()
+						local base_url = fields[1]
+						local username = fields[2]
+						local password = fields[3]
+
+						settings:updateServerConfig(base_url, username, password)
+						UIManager:close(dialog)
+						UI.showSettingsSaved()
+
+						if on_save then
+							on_save()
+						end
+					end,
+				},
+			},
+		},
+	})
+
+	UIManager:show(dialog)
+	dialog:onShowKeyboard()
+end
+
+--- Build the main menu structure for the plugin
+-- @param handlers table Callback handlers for menu actions
+--   - on_sync: function() Called when sync is triggered
+--   - on_configure: function() Called when configure is triggered
+--   - is_autosync_enabled: function() Returns autosync state
+--   - on_toggle_autosync: function() Called when autosync is toggled
+-- @return table Menu item table for KOReader
+function UI.buildMenuItems(handlers)
+	return {
+		text = _("Crossbill Sync"),
+		sorting_hint = "tools",
+		sub_item_table = {
+			{
+				text = _("Sync Current Book"),
+				callback = handlers.on_sync,
+			},
+			{
+				text = _("Configure Server"),
+				callback = handlers.on_configure,
+			},
+			{
+				text = _("Auto-sync"),
+				checked_func = handlers.is_autosync_enabled,
+				callback = handlers.on_toggle_autosync,
+			},
+		},
+	}
+end
+
+return UI


### PR DESCRIPTION
Refactored the 805-line main.lua into a clean modular structure with clear separation of concerns:

- modules/settings.lua: Configuration management with typed accessors
- modules/network.lua: HTTP/HTTPS and WiFi utilities
- modules/auth.lua: Authentication flow (login, token refresh)
- modules/api_client.lua: Server API communication
- modules/highlight_extractor.lua: Highlight extraction from memory/disk
- modules/book_metadata.lua: Book metadata and cover extraction
- modules/ui.lua: User interface components and dialogs

This improves:
- Maintainability: Each module has a single responsibility
- Testability: Modules can be tested in isolation
- Readability: main.lua reduced from 805 to 219 lines
- Reusability: Modules expose clean APIs for future extensions