### PR TITLE
Filter out reading sessions shorter than minimum duration

### DIFF
--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -57,6 +57,11 @@ class Settings:
         "yes",
     )
 
+    # Reading sessions
+    MINIMUM_READING_SESSION_DURATION: int = int(
+        os.getenv("MINIMUM_READING_SESSION_DURATION", "120")
+    )
+
 
 def configure_logging(environment: str = "development") -> None:
     """Configure structured logging with structlog."""

--- a/backend/src/services/reading_session_service.py
+++ b/backend/src/services/reading_session_service.py
@@ -4,6 +4,7 @@ import structlog
 from sqlalchemy.orm import Session
 
 from src import repositories, schemas
+from src.config import get_settings
 from src.exceptions import BookNotFoundError
 from src.repositories.reading_session_repository import ReadingSessionRepository
 from src.schemas.book_schemas import BookCreate
@@ -70,6 +71,15 @@ class ReadingSessionService:
         # Filter away sessions where start and end points are the same
         sessions = [
             s for s in sessions if s.start_xpoint != s.end_xpoint or s.start_page != s.end_page
+        ]
+
+        # Filter out sessions shorter than minimum duration
+        settings = get_settings()
+        min_duration = settings.MINIMUM_READING_SESSION_DURATION
+        sessions = [
+            s
+            for s in sessions
+            if (s.end_time - s.start_time).total_seconds() >= min_duration
         ]
 
         for session in sessions:


### PR DESCRIPTION
Add MINIMUM_READING_SESSION_DURATION config variable (default 120 seconds) and filter out sessions with duration below this threshold before saving to the database in the reading session upload flow.