### PR TITLE
Add pagination support to GET reading sessions endpoint

### DIFF
--- a/backend/src/repositories/reading_session_repository.py
+++ b/backend/src/repositories/reading_session_repository.py
@@ -95,7 +95,7 @@ class ReadingSessionRepository:
         return count_after - count_before
 
     def get_by_book_id(
-        self, book_id: int, user_id: int, limit: int = 100, offset: int = 0
+        self, book_id: int, user_id: int, limit: int = 30, offset: int = 0
     ) -> Sequence[models.ReadingSession]:
         """Get reading sessions for a specific book, ordered by start_time descending."""
         stmt = (

--- a/backend/src/routers/books.py
+++ b/backend/src/routers/books.py
@@ -941,7 +941,7 @@ def get_book_reading_sessions(
     book_id: int,
     db: DatabaseSession,
     current_user: Annotated[User, Depends(get_current_user)],
-    limit: int = Query(100, ge=1, le=1000, description="Maximum sessions to return"),
+    limit: int = Query(30, ge=1, le=1000, description="Maximum sessions to return"),
     offset: int = Query(0, ge=0, description="Number of sessions to skip"),
 ) -> schemas.ReadingSessionsResponse:
     """

--- a/backend/src/schemas/reading_session_schemas.py
+++ b/backend/src/schemas/reading_session_schemas.py
@@ -92,7 +92,9 @@ class ReadingSessionUploadResponse(BaseModel):
 
 
 class ReadingSessionsResponse(BaseModel):
-    """Schema for list of reading sessions response."""
+    """Schema for paginated reading sessions response."""
 
     sessions: list[ReadingSession] = Field(..., description="List of reading sessions")
     total: int = Field(..., ge=0, description="Total number of sessions")
+    offset: int = Field(..., ge=0, description="Current offset")
+    limit: int = Field(..., ge=1, description="Current limit")

--- a/backend/src/services/reading_session_service.py
+++ b/backend/src/services/reading_session_service.py
@@ -141,7 +141,7 @@ class ReadingSessionService:
         self,
         book_id: int,
         user_id: int,
-        limit: int = 100,
+        limit: int = 30,
         offset: int = 0,
     ) -> schemas.ReadingSessionsResponse:
         """Get reading sessions for a specific book."""
@@ -156,4 +156,6 @@ class ReadingSessionService:
         return schemas.ReadingSessionsResponse(
             sessions=[schemas.ReadingSession.model_validate(s) for s in sessions],
             total=total,
+            offset=offset,
+            limit=limit,
         )


### PR DESCRIPTION
- Add offset and limit fields to ReadingSessionsResponse schema
- Change default limit from 100 to 30 sessions per page
- Update endpoint, service, and repository with new defaults