### PR TITLE
Add EMBEDDED_WORKER and WORKER_CONCURRENCY settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,12 @@ ALLOW_USER_REGISTRATION=true
 # AI_MODEL_NAME=minimax/minimax-m2.5   # or any OpenRouter model slug
 # OPENROUTER_API_KEY=<apikey here>
 
+# Background worker
+# By default the app runs the SAQ worker in-process (embedded mode).
+# Set EMBEDDED_WORKER=false to disable it and run a separate worker container instead.
+# EMBEDDED_WORKER=true
+# WORKER_CONCURRENCY=2
+
 # S3-compatible storage (optional)
 # When configured, files are stored in S3 instead of local disk.
 # This is required for multi-container deployments (e.g., Railway)

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -79,6 +79,10 @@ class Settings(BaseSettings):
     # openrouter
     OPENROUTER_API_KEY: str | None = None
 
+    # Worker
+    EMBEDDED_WORKER: bool = True
+    WORKER_CONCURRENCY: int = 2
+
     # S3-compatible storage (optional — if set, files are stored in S3 instead of local disk)
     S3_ENDPOINT_URL: str | None = None
     S3_ACCESS_KEY_ID: str | None = None

--- a/backend/src/database.py
+++ b/backend/src/database.py
@@ -36,8 +36,15 @@ def _make_async_url(url: str) -> str:
 
 
 def initialize_database(settings: Settings) -> None:
-    """Initialize database engine and session factory once at startup."""
+    """Initialize database engine and session factory once at startup.
+
+    Subsequent calls are no-ops so the embedded worker does not create a
+    duplicate connection pool when the FastAPI lifespan already initialised it.
+    """
     global _engine, _session_factory  # noqa: PLW0603
+
+    if _engine is not None:
+        return
 
     async_url = _make_async_url(settings.DATABASE_URL)
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -140,7 +140,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     yield
 
-    # Stop embedded worker gracefully
+    # Stop embedded worker gracefully.
+    # worker.stop() signals the run-loop to exit, which should resolve
+    # worker_task naturally.  The cancel() is a defensive fallback in case
+    # start() does not exit cleanly (e.g. stuck awaiting a job).
     if embedded_worker is not None and worker_task is not None:
         await embedded_worker.stop()
         worker_task.cancel()

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,5 +1,7 @@
 """Main FastAPI application."""
 
+import asyncio
+import contextlib
 import os
 import time
 import uuid
@@ -126,7 +128,25 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     queue_service = SaqJobQueueService(saq_queue)
     container.job_queue_service.override(queue_service)
 
+    # Start embedded worker if enabled (runs SAQ in the same process)
+    embedded_worker = None
+    worker_task: asyncio.Task[None] | None = None
+    if settings.EMBEDDED_WORKER:
+        from src.worker import create_embedded_worker  # noqa: PLC0415
+
+        embedded_worker = create_embedded_worker(saq_queue, concurrency=settings.WORKER_CONCURRENCY)
+        worker_task = asyncio.create_task(embedded_worker.start())
+        logger.info("embedded_worker_started", concurrency=settings.WORKER_CONCURRENCY)
+
     yield
+
+    # Stop embedded worker gracefully
+    if embedded_worker is not None and worker_task is not None:
+        await embedded_worker.stop()
+        worker_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await worker_task
+        logger.info("embedded_worker_stopped")
 
     await saq_queue.disconnect()
     container.job_queue_service.reset_override()

--- a/backend/src/worker.py
+++ b/backend/src/worker.py
@@ -5,7 +5,6 @@ Start with: saq src.worker.worker_settings
 For embedded mode (in-process with FastAPI), use create_embedded_worker().
 """
 
-import os
 import signal
 from typing import ClassVar
 
@@ -146,7 +145,7 @@ def _build_worker_settings() -> SettingsDict[Context]:
     return {
         "queue": _get_queue(),
         "functions": [generate_chapter_prereading],
-        "concurrency": int(os.getenv("WORKER_CONCURRENCY", "5")),
+        "concurrency": _get_app_settings().WORKER_CONCURRENCY,
         "startup": startup,
         "shutdown": shutdown,
         "after_process": after_process,

--- a/backend/src/worker.py
+++ b/backend/src/worker.py
@@ -36,23 +36,42 @@ from src.infrastructure.reading.repositories.chapter_prereading_repository impor
 
 logger = structlog.get_logger(__name__)
 
-app_settings = get_settings()
-queue = create_queue(app_settings.DATABASE_URL)
-
 _session_factory: async_sessionmaker[AsyncSession] | None = None
+
+# Settings and queue are created lazily to avoid side effects when importing
+# this module from the FastAPI app (which only needs create_embedded_worker).
+_app_settings = None
+_queue = None
+
+
+def _get_app_settings():  # noqa: ANN202
+    """Get cached settings (lazy singleton)."""
+    global _app_settings  # noqa: PLW0603
+    if _app_settings is None:
+        _app_settings = get_settings()
+    return _app_settings
+
+
+def _get_queue() -> Queue:
+    """Get cached SAQ queue (lazy singleton)."""
+    global _queue  # noqa: PLW0603
+    if _queue is None:
+        _queue = create_queue(_get_app_settings().DATABASE_URL)
+    return _queue
 
 
 def _build_file_repo() -> S3FileRepository | FileRepository:
     """Build the appropriate file repository based on config."""
-    if app_settings.s3_enabled:
+    settings = _get_app_settings()
+    if settings.s3_enabled:
         client = boto3.client(
             "s3",
-            endpoint_url=app_settings.S3_ENDPOINT_URL,
-            aws_access_key_id=app_settings.S3_ACCESS_KEY_ID,
-            aws_secret_access_key=app_settings.S3_SECRET_ACCESS_KEY,
-            region_name=app_settings.S3_REGION,
+            endpoint_url=settings.S3_ENDPOINT_URL,
+            aws_access_key_id=settings.S3_ACCESS_KEY_ID,
+            aws_secret_access_key=settings.S3_SECRET_ACCESS_KEY,
+            region_name=settings.S3_REGION,
         )
-        return S3FileRepository(s3_client=client, bucket_name=app_settings.S3_BUCKET_NAME)  # type: ignore[arg-type]
+        return S3FileRepository(s3_client=client, bucket_name=settings.S3_BUCKET_NAME)  # type: ignore[arg-type]
     return FileRepository()
 
 
@@ -76,10 +95,11 @@ def _build_prereading_handler(db: AsyncSession) -> PrereadingTaskHandler:
 async def startup(ctx: Context) -> None:
     """Initialize worker resources."""
     logger.info("worker_starting")
-    initialize_database(app_settings)
+    settings = _get_app_settings()
+    initialize_database(settings)
 
     global _session_factory  # noqa: PLW0603
-    _session_factory = get_session_factory(app_settings)
+    _session_factory = get_session_factory(settings)
 
     logger.info("worker_started")
 
@@ -121,14 +141,27 @@ async def after_process(ctx: Context) -> None:
         await handler.after_process(ctx)
 
 
-worker_settings: SettingsDict[Context] = {
-    "queue": queue,
-    "functions": [generate_chapter_prereading],
-    "concurrency": int(os.getenv("WORKER_CONCURRENCY", "5")),
-    "startup": startup,
-    "shutdown": shutdown,
-    "after_process": after_process,
-}
+def _build_worker_settings() -> SettingsDict[Context]:
+    """Build SAQ worker settings lazily (called on first access)."""
+    return {
+        "queue": _get_queue(),
+        "functions": [generate_chapter_prereading],
+        "concurrency": int(os.getenv("WORKER_CONCURRENCY", "5")),
+        "startup": startup,
+        "shutdown": shutdown,
+        "after_process": after_process,
+    }
+
+
+def __getattr__(name: str) -> SettingsDict[Context]:
+    """Module-level __getattr__ for lazy worker_settings access.
+
+    SAQ CLI does ``import src.worker; src.worker.worker_settings`` which
+    triggers this on first access, keeping the import itself side-effect-free.
+    """
+    if name == "worker_settings":
+        return _build_worker_settings()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 class EmbeddedWorker(Worker[Context]):

--- a/backend/src/worker.py
+++ b/backend/src/worker.py
@@ -7,6 +7,7 @@ For embedded mode (in-process with FastAPI), use create_embedded_worker().
 
 import os
 import signal
+from typing import ClassVar
 
 import boto3
 import structlog
@@ -137,7 +138,7 @@ class EmbeddedWorker(Worker[Context]):
     The app lifespan calls worker.stop() on shutdown instead.
     """
 
-    SIGNALS: list[signal.Signals] = []
+    SIGNALS: ClassVar[list[signal.Signals]] = []
 
 
 def create_embedded_worker(queue: Queue, concurrency: int = 2) -> EmbeddedWorker:

--- a/backend/src/worker.py
+++ b/backend/src/worker.py
@@ -1,12 +1,16 @@
 """SAQ worker entrypoint.
 
 Start with: saq src.worker.worker_settings
+
+For embedded mode (in-process with FastAPI), use create_embedded_worker().
 """
 
 import os
+import signal
 
 import boto3
 import structlog
+from saq import Queue, Worker
 from saq.types import Context, SettingsDict
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -124,3 +128,25 @@ worker_settings: SettingsDict[Context] = {
     "shutdown": shutdown,
     "after_process": after_process,
 }
+
+
+class EmbeddedWorker(Worker[Context]):
+    """SAQ Worker that skips signal handler registration.
+
+    When running inside the FastAPI process, uvicorn owns SIGINT/SIGTERM.
+    The app lifespan calls worker.stop() on shutdown instead.
+    """
+
+    SIGNALS: list[signal.Signals] = []
+
+
+def create_embedded_worker(queue: Queue, concurrency: int = 2) -> EmbeddedWorker:
+    """Create a Worker instance for running inside the app process."""
+    return EmbeddedWorker(
+        queue=queue,
+        functions=[generate_chapter_prereading],
+        concurrency=concurrency,
+        startup=[startup],
+        shutdown=[shutdown],
+        after_process=after_process,
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,8 @@ services:
 
   # Background job worker (SAQ) — processes async tasks like batch AI prereading generation.
   # Uses the same image as the app with a different entrypoint. Requires AI_PROVIDER config for AI tasks.
+  # NOTE: Not needed when EMBEDDED_WORKER=true (the default) — the app runs the worker in-process.
+  # Use a separate worker container only if you need process isolation or higher concurrency.
   worker:
     image: tumetsu/crossbill:latest
     container_name: crossbill-worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,39 +59,42 @@ services:
 
   # Background job worker (SAQ) — processes async tasks like batch AI prereading generation.
   # Uses the same image as the app with a different entrypoint. Requires AI_PROVIDER config for AI tasks.
-  # NOTE: Not needed when EMBEDDED_WORKER=true (the default) — the app runs the worker in-process.
-  # Use a separate worker container only if you need process isolation or higher concurrency.
-  worker:
-    image: tumetsu/crossbill:latest
-    container_name: crossbill-worker
-    restart: unless-stopped
-    pull_policy: always
-    env_file: .env
-    command: ["saq", "src.worker.worker_settings"]
-    environment:
-      DATABASE_URL: postgresql://crossbill:${POSTGRES_PASSWORD:-crossbill_secure_password}@postgres:5432/crossbill
-      ENVIRONMENT: production
-      AI_PROVIDER: ${AI_PROVIDER:-}
-      AI_MODEL_NAME: ${AI_MODEL_NAME:-}
-      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
-      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-}
-      WORKER_CONCURRENCY: ${WORKER_CONCURRENCY:-5}
-      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-}
-      S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID:-}
-      S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY:-}
-      S3_BUCKET_NAME: ${S3_BUCKET_NAME:-}
-      S3_REGION: ${S3_REGION:-us-east-1}
-    volumes:
-      - type: bind
-        source: /path/on/host/for/crossbill/book-files
-        target: /app/book-files
-    depends_on:
-      postgres:
-        condition: service_healthy
-    networks:
-      - crossbill-network
+  #
+  # NOT NEEDED by default — the app runs the worker in-process (EMBEDDED_WORKER=true).
+  # Uncomment this service and set EMBEDDED_WORKER=false in the app if you need process isolation
+  # or want to scale the worker independently.
+  #
+  # worker:
+  #   image: tumetsu/crossbill:latest
+  #   container_name: crossbill-worker
+  #   restart: unless-stopped
+  #   pull_policy: always
+  #   env_file: .env
+  #   command: ["saq", "src.worker.worker_settings"]
+  #   environment:
+  #     DATABASE_URL: postgresql://crossbill:${POSTGRES_PASSWORD:-crossbill_secure_password}@postgres:5432/crossbill
+  #     ENVIRONMENT: production
+  #     AI_PROVIDER: ${AI_PROVIDER:-}
+  #     AI_MODEL_NAME: ${AI_MODEL_NAME:-}
+  #     OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+  #     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+  #     GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
+  #     OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-}
+  #     WORKER_CONCURRENCY: ${WORKER_CONCURRENCY:-5}
+  #     S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-}
+  #     S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID:-}
+  #     S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY:-}
+  #     S3_BUCKET_NAME: ${S3_BUCKET_NAME:-}
+  #     S3_REGION: ${S3_REGION:-us-east-1}
+  #   volumes:
+  #     - type: bind
+  #       source: /path/on/host/for/crossbill/book-files
+  #       target: /app/book-files
+  #   depends_on:
+  #     postgres:
+  #       condition: service_healthy
+  #   networks:
+  #     - crossbill-network
 
   # Optional: S3-compatible object storage for shared file access between app and worker.
   # Not needed if using an external S3 service (e.g., Railway Object Storage, AWS S3).


### PR DESCRIPTION
These control whether the SAQ worker runs in-process with the FastAPI
app (to save memory on single-container deployments like Railway)
and its concurrency level.

https://claude.ai/code/session_015xLdBmhXMYADBQHYdEhCBK