### PR TITLE
fix: escape LIKE wildcards in search queries

### DIFF
--- a/backend/src/infrastructure/common/sql.py
+++ b/backend/src/infrastructure/common/sql.py
@@ -1,0 +1,14 @@
+LIKE_ESCAPE_CHAR = "\\"
+
+
+def escape_like_pattern(text: str) -> str:
+    """Escape LIKE/ILIKE wildcard characters in user-supplied search text.
+
+    Pair with ``.ilike(pattern, escape=LIKE_ESCAPE_CHAR)`` so ``%`` and ``_`` in
+    user input match literally instead of acting as wildcards.
+    """
+    return (
+        text.replace(LIKE_ESCAPE_CHAR, LIKE_ESCAPE_CHAR * 2)
+        .replace("%", LIKE_ESCAPE_CHAR + "%")
+        .replace("_", LIKE_ESCAPE_CHAR + "_")
+    )

--- a/backend/src/infrastructure/library/repositories/book_repository.py
+++ b/backend/src/infrastructure/library/repositories/book_repository.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import selectinload
 from src.domain.common.value_objects.ids import BookId, UserId
 from src.domain.library.entities.book import Book
 from src.domain.library.entities.tag import Tag
+from src.infrastructure.common.sql import LIKE_ESCAPE_CHAR, escape_like_pattern
 from src.infrastructure.library.mappers.book_mapper import BookMapper
 from src.infrastructure.library.mappers.tag_mapper import TagMapper
 from src.models import Book as BookORM
@@ -174,9 +175,10 @@ class BookRepository:
         # Build base filter conditions - always filter by user
         filters = [BookORM.user_id == user_id.value]
         if search_text:
-            search_pattern = f"%{search_text}%"
+            search_pattern = f"%{escape_like_pattern(search_text)}%"
             filters.append(
-                (BookORM.title.ilike(search_pattern)) | (BookORM.author.ilike(search_pattern))
+                BookORM.title.ilike(search_pattern, escape=LIKE_ESCAPE_CHAR)
+                | BookORM.author.ilike(search_pattern, escape=LIKE_ESCAPE_CHAR)
             )
 
         if include_only_with_flashcards:

--- a/backend/src/infrastructure/reading/repositories/highlight_repository.py
+++ b/backend/src/infrastructure/reading/repositories/highlight_repository.py
@@ -267,9 +267,7 @@ class HighlightRepository:
             else:
                 # SQLite: Use LIKE-based search
                 escaped = escape_like_pattern(search_text)
-                stmt = stmt.where(
-                    HighlightORM.text.ilike(f"%{escaped}%", escape=LIKE_ESCAPE_CHAR)
-                )
+                stmt = stmt.where(HighlightORM.text.ilike(f"%{escaped}%", escape=LIKE_ESCAPE_CHAR))
 
         # Add optional book_id filter
         if book_id is not None:

--- a/backend/src/infrastructure/reading/repositories/highlight_repository.py
+++ b/backend/src/infrastructure/reading/repositories/highlight_repository.py
@@ -25,6 +25,7 @@ from src.domain.library.entities.book import Book
 from src.domain.library.entities.chapter import Chapter
 from src.domain.reading.entities.highlight import Highlight
 from src.domain.reading.entities.highlight_tag import HighlightTag
+from src.infrastructure.common.sql import LIKE_ESCAPE_CHAR, escape_like_pattern
 from src.infrastructure.learning.mappers.flashcard_mapper import FlashcardMapper
 from src.infrastructure.library.mappers.book_mapper import BookMapper
 from src.infrastructure.library.mappers.chapter_mapper import ChapterMapper
@@ -265,7 +266,10 @@ class HighlightRepository:
                 stmt = stmt.where(HighlightORM.text_search_vector.op("@@")(search_query))
             else:
                 # SQLite: Use LIKE-based search
-                stmt = stmt.where(HighlightORM.text.ilike(f"%{search_text}%"))
+                escaped = escape_like_pattern(search_text)
+                stmt = stmt.where(
+                    HighlightORM.text.ilike(f"%{escaped}%", escape=LIKE_ESCAPE_CHAR)
+                )
 
         # Add optional book_id filter
         if book_id is not None:

--- a/backend/tests/unit/infrastructure/test_sql.py
+++ b/backend/tests/unit/infrastructure/test_sql.py
@@ -1,0 +1,23 @@
+from src.infrastructure.common.sql import LIKE_ESCAPE_CHAR, escape_like_pattern
+
+
+def test_escape_like_pattern_leaves_plain_text_unchanged() -> None:
+    assert escape_like_pattern("hello world") == "hello world"
+
+
+def test_escape_like_pattern_escapes_percent() -> None:
+    assert escape_like_pattern("50%") == "50\\%"
+
+
+def test_escape_like_pattern_escapes_underscore() -> None:
+    assert escape_like_pattern("foo_bar") == "foo\\_bar"
+
+
+def test_escape_like_pattern_escapes_backslash_first() -> None:
+    # Backslash must be escaped before % / _ so we don't double-escape our
+    # own escape character.
+    assert escape_like_pattern("a\\%b") == "a\\\\\\%b"
+
+
+def test_escape_like_pattern_escape_char_is_backslash() -> None:
+    assert LIKE_ESCAPE_CHAR == "\\"


### PR DESCRIPTION
## Summary
- Closes #305
- Adds `escape_like_pattern()` helper in `backend/src/infrastructure/common/sql.py` that escapes `\`, `%`, and `_` (backslash first, to avoid double-escaping).
- Uses it in the two `ilike()` search paths — highlight text search (SQLite branch) and book title/author search — and passes an explicit `escape=LIKE_ESCAPE_CHAR` so the DB treats `\` as the escape character.

## Why
User-supplied search text was interpolated into `ilike()` patterns without escaping wildcards. Not classic SQL injection (SQLAlchemy still parameterizes), but `%` / `_` in input enabled LIKE-pattern DoS and search-result manipulation. PostgreSQL's highlight search uses `plainto_tsquery` and is unaffected, so this mainly matters for SQLite/dev and the book search path.

## Test plan
- [x] New unit tests in `tests/unit/infrastructure/test_sql.py` cover plain text, `%`, `_`, and backslash escaping order
- [x] `uv run pytest tests/unit/infrastructure/test_sql.py tests/test_books.py tests/test_highlights.py` — all 32 pass
- [x] `uv run ruff check` clean on touched files
- [x] `uv run pyright` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)