### PR TITLE
Require ADMIN_PASSWORD to be set and non-default (#303)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,12 +25,26 @@ PORT=8000
 # Or specify specific origins (secure):
 #CORS_ORIGINS='["https://mydomain.example.com", "http://localhost:3000","http://localhost:5173","http://localhost:8000"]'
 
-# Admin setup (for first-time initialization)
-# ADMIN_PASSWORD must be set — startup fails if it is empty or equal to "admin".
-# It is only consumed on first run to provision the admin user; you can change
-# the password from the UI afterwards.
+# Admin setup (first-run bootstrap)
+#
+# ADMIN_PASSWORD is REQUIRED — the backend refuses to start if it is empty
+# or set to the insecure literal "admin". It is only consumed on the very
+# first startup to provision the initial admin user; after that the value
+# is ignored and you manage the password from the UI.
+#
+# To set it:
+#   1. Generate a strong password, e.g.
+#        openssl rand -base64 24
+#   2. Paste it below (or export ADMIN_PASSWORD in your shell / secrets
+#      manager / docker-compose env).
+#   3. Start the backend once so the admin user is created, then sign in
+#      and change the password from the UI. You can safely clear or rotate
+#      this variable afterwards.
+#
+# ADMIN_USERNAME is the login name for that initial user and defaults to
+# "admin" — change it here if you prefer a different username.
 ADMIN_USERNAME=admin
-ADMIN_PASSWORD=change-me-before-first-run
+ADMIN_PASSWORD=
 
 ACCESS_TOKEN_EXPIRE_MINUTES=15
 REFRESH_TOKEN_EXPIRE_DAYS=30

--- a/.env.example
+++ b/.env.example
@@ -26,9 +26,11 @@ PORT=8000
 #CORS_ORIGINS='["https://mydomain.example.com", "http://localhost:3000","http://localhost:5173","http://localhost:8000"]'
 
 # Admin setup (for first-time initialization)
-# If ADMIN_PASSWORD is not set and the admin user has no password, this password will be hashed and saved on startup
-# ADMIN_USERNAME=admin
-# ADMIN_PASSWORD=admin
+# ADMIN_PASSWORD must be set — startup fails if it is empty or equal to "admin".
+# It is only consumed on first run to provision the admin user; you can change
+# the password from the UI afterwards.
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=change-me-before-first-run
 
 ACCESS_TOKEN_EXPIRE_MINUTES=15
 REFRESH_TOKEN_EXPIRE_DAYS=30

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -40,9 +40,9 @@ class Settings(BaseSettings):
     # CORS
     CORS_ORIGINS: list[str] = ["*"]
 
-    # Admin setup (for first-time initialization)
+    # Admin setup (for first-time initialization on a fresh deployment)
     ADMIN_USERNAME: str = "admin"
-    ADMIN_PASSWORD: str = "admin"  # noqa: S105
+    ADMIN_PASSWORD: str = ""
 
     # Auth
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 15
@@ -112,6 +112,23 @@ class Settings(BaseSettings):
     def strip_admin_password(cls, value: str) -> str:
         """Strip whitespace from admin password."""
         return value.strip()
+
+    @model_validator(mode="after")
+    def validate_admin_password(self) -> "Settings":
+        """Require ADMIN_PASSWORD to be set to a non-default value for first-run provisioning."""
+        if not self.ADMIN_PASSWORD:
+            msg = (
+                "ADMIN_PASSWORD must be set (e.g. in your .env file) so the initial "
+                "admin user can be provisioned on first startup."
+            )
+            raise ValueError(msg)
+        if self.ADMIN_PASSWORD.lower() == "admin":
+            msg = (
+                "ADMIN_PASSWORD must not be set to the insecure default 'admin'. "
+                "Choose a strong password — you can change it again from the UI after first login."
+            )
+            raise ValueError(msg)
+        return self
 
     @model_validator(mode="after")
     def validate_ai_provider_config(self) -> "Settings":

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -70,11 +70,6 @@ STATIC_DIR = (Path(__file__).parent.parent / "static").resolve()
 
 async def _initialize_admin_password() -> None:
     """Initialize admin user password from environment variable if not set."""
-    if not settings.ADMIN_PASSWORD:
-        logger.info("admin_password_skip", reason="ADMIN_PASSWORD not set")
-        return
-
-    # Use singleton session factory instead of creating new engine
     session_factory = get_session_factory(settings)
     async with session_factory() as db:
         # Use repository to find and update admin user

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -2,6 +2,12 @@
 
 import logging
 import os
+
+# Settings are constructed at import time in src.main, so env vars that feed
+# the Settings validator must be set before any src.* imports below.
+os.environ.setdefault("TESTING", "1")
+os.environ.setdefault("ADMIN_PASSWORD", "test-admin-password")
+
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from datetime import datetime as dt
 from typing import Any
@@ -9,7 +15,11 @@ from typing import Any
 import pytest
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import event, select
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 from sqlalchemy.pool import StaticPool
 
 from src.database import Base, get_db
@@ -131,9 +141,6 @@ async def create_test_highlight_style(
     await db_session.refresh(style)
     return style
 
-
-# Set TESTING environment variable to skip database initialization in main.py
-os.environ["TESTING"] = "1"
 
 # Test database URL (in-memory SQLite with aiosqlite)
 TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"


### PR DESCRIPTION
Fixes #303.

## Summary
- Removed the insecure `admin:admin` code default from `Settings`.
- Added a model validator that fails startup if `ADMIN_PASSWORD` is empty or equal to `"admin"` (case-insensitive), with a clear actionable error message.
- Removed the now-unreachable empty-password guard in `_initialize_admin_password`.
- Tests bootstrap `TESTING` and `ADMIN_PASSWORD` in `conftest.py` before importing `src.*` so the validator is satisfied during test collection.
- Updated `.env.example` to document that `ADMIN_PASSWORD` must be set before first run.

`ADMIN_USERNAME` still defaults to `admin` — only the password is the secret.

## Test plan
- [x] `uv run ruff check` clean
- [x] `uv run ruff format` clean
- [x] `uv run pyright` clean (0 errors)
- [x] `uv run pytest` — 313/313 passing
- [x] Smoke test: `Settings()` with `ADMIN_PASSWORD="admin"` → `ValidationError`
- [x] Smoke test: `Settings()` with empty `ADMIN_PASSWORD` → `ValidationError`
- [x] Smoke test: `Settings()` with a strong password → accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)