### PR TITLE
Secure CORS defaults and reject wildcard in production (#304)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,11 +19,11 @@ ENVIRONMENT=development
 # Port (for docker-compose)
 PORT=8000
 
-# CORS - Allow requests from these origins (comma-separated)
-# Use "*" to allow all origins (default)
-# CORS_ORIGINS='["*"]'
-# Or specify specific origins (secure):
-#CORS_ORIGINS='["https://mydomain.example.com", "http://localhost:3000","http://localhost:5173","http://localhost:8000"]'
+# CORS - Allow requests from these origins.
+# Defaults to localhost dev ports (3000, 5173, 8000) when unset.
+# In production, CORS_ORIGINS MUST be set to explicit origins — wildcard "*"
+# and empty lists are rejected at startup.
+#CORS_ORIGINS='["https://mydomain.example.com"]'
 
 # Admin setup (first-run bootstrap)
 #

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -38,7 +38,11 @@ class Settings(BaseSettings):
     ENVIRONMENT: Literal["development", "production", "test"] = "development"
 
     # CORS
-    CORS_ORIGINS: list[str] = ["*"]
+    CORS_ORIGINS: list[str] = [
+        "http://localhost:3000",
+        "http://localhost:5173",
+        "http://localhost:8000",
+    ]
 
     # Admin setup (for first-time initialization on a fresh deployment)
     ADMIN_USERNAME: str = "admin"
@@ -127,6 +131,19 @@ class Settings(BaseSettings):
                 "ADMIN_PASSWORD must not be set to the insecure default 'admin'. "
                 "Choose a strong password — you can change it again from the UI after first login."
             )
+            raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
+    def validate_cors_origins_in_production(self) -> "Settings":
+        """Reject wildcard or empty CORS origins in production."""
+        if self.ENVIRONMENT != "production":
+            return self
+        if not self.CORS_ORIGINS:
+            msg = "CORS_ORIGINS must be set to explicit origins in production"
+            raise ValueError(msg)
+        if "*" in self.CORS_ORIGINS:
+            msg = "CORS_ORIGINS must not contain wildcard '*' in production"
             raise ValueError(msg)
         return self
 

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -1,0 +1,52 @@
+"""Tests for Settings configuration validation."""
+
+import pytest
+
+from src.config import Settings
+
+
+def _build_settings(**overrides: object) -> Settings:
+    defaults: dict[str, object] = {
+        "SECRET_KEY": "test-secret",
+        "REFRESH_TOKEN_SECRET_KEY": "test-refresh-secret",
+        "ADMIN_PASSWORD": "test-admin-password",
+    }
+    defaults.update(overrides)
+    return Settings(**defaults)  # type: ignore[arg-type]
+
+
+class TestCorsOriginsValidation:
+    def test_development_empty_origins_ok(self) -> None:
+        settings = _build_settings(ENVIRONMENT="development", CORS_ORIGINS=[])
+        assert settings.CORS_ORIGINS == []
+
+    def test_development_wildcard_ok(self) -> None:
+        settings = _build_settings(ENVIRONMENT="development", CORS_ORIGINS=["*"])
+        assert settings.CORS_ORIGINS == ["*"]
+
+    def test_development_default_contains_localhost(self) -> None:
+        settings = _build_settings(ENVIRONMENT="development")
+        assert "http://localhost:5173" in settings.CORS_ORIGINS
+        assert "*" not in settings.CORS_ORIGINS
+
+    def test_production_empty_origins_rejected(self) -> None:
+        with pytest.raises(ValueError, match="CORS_ORIGINS must be set"):
+            _build_settings(ENVIRONMENT="production", CORS_ORIGINS=[])
+
+    def test_production_wildcard_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must not contain wildcard"):
+            _build_settings(ENVIRONMENT="production", CORS_ORIGINS=["*"])
+
+    def test_production_wildcard_mixed_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must not contain wildcard"):
+            _build_settings(
+                ENVIRONMENT="production",
+                CORS_ORIGINS=["https://example.com", "*"],
+            )
+
+    def test_production_explicit_origins_ok(self) -> None:
+        settings = _build_settings(
+            ENVIRONMENT="production",
+            CORS_ORIGINS=["https://example.com"],
+        )
+        assert settings.CORS_ORIGINS == ["https://example.com"]


### PR DESCRIPTION
## Summary
- Change `CORS_ORIGINS` default from `["*"]` to the localhost dev ports (`3000`, `5173`, `8000`) so no wildcard is shipped by default.
- Add a `Settings` model validator that rejects empty `CORS_ORIGINS` or a `"*"` entry when `ENVIRONMENT=production`, forcing production deployments to declare explicit origins.
- Update `.env.example` to document the new behavior and drop the wildcard example.

Fixes #304.

## Test plan
- [x] `uv run pytest` (320 passed)
- [x] `uv run pyright src/config.py tests/unit/test_config.py` (0 errors)
- [x] `uv run ruff check` / `ruff format`
- [x] New `tests/unit/test_config.py` covers: dev empty, dev wildcard, dev default, prod empty rejected, prod wildcard rejected, prod mixed wildcard rejected, prod explicit origins ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)