### PR TITLE
Require JWT secret keys to be set and at least 32 bytes (#302)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,12 @@ DATABASE_URL=postgresql://crossbill:crossbill_dev_password@localhost:5432/crossb
 # SQLite (for local development without Docker)
 # DATABASE_URL=sqlite:///./crossbill.db
 
-# Generate secret key:
-# openssl rand -hex 32
-SECRET_KEY=123
+# JWT signing secrets — REQUIRED. The backend refuses to start if either is
+# empty or shorter than 32 bytes. Generate strong random values with:
+#   python -c "import secrets; print(secrets.token_urlsafe(32))"
+# (or `openssl rand -hex 32`). Use different values for access and refresh.
+SECRET_KEY=
+REFRESH_TOKEN_SECRET_KEY=
 
 # PostgreSQL password for docker-compose (production)
 # CHANGE THIS IN PRODUCTION!
@@ -48,7 +51,6 @@ ADMIN_PASSWORD=
 
 ACCESS_TOKEN_EXPIRE_MINUTES=15
 REFRESH_TOKEN_EXPIRE_DAYS=30
-REFRESH_TOKEN_SECRET_KEY=random secret
 COOKIE_SECURE=true
 
 # Password pepper - Secret value added to all passwords before hashing

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -118,6 +118,21 @@ class Settings(BaseSettings):
         return value.strip()
 
     @model_validator(mode="after")
+    def validate_jwt_secret_keys(self) -> "Settings":
+        """Require JWT signing secrets to be set and long enough to resist brute force."""
+        minimum_length = 32
+        for field_name in ("SECRET_KEY", "REFRESH_TOKEN_SECRET_KEY"):
+            value: str = getattr(self, field_name)
+            if len(value.encode("utf-8")) < minimum_length:
+                msg = (
+                    f"{field_name} must be set to at least {minimum_length} bytes. "
+                    "Generate one with: "
+                    'python -c "import secrets; print(secrets.token_urlsafe(32))"'
+                )
+                raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
     def validate_admin_password(self) -> "Settings":
         """Require ADMIN_PASSWORD to be set to a non-default value for first-run provisioning."""
         if not self.ADMIN_PASSWORD:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,6 +7,11 @@ import os
 # the Settings validator must be set before any src.* imports below.
 os.environ.setdefault("TESTING", "1")
 os.environ.setdefault("ADMIN_PASSWORD", "test-admin-password")
+os.environ.setdefault("SECRET_KEY", "test-secret-key-at-least-32-bytes-long")
+os.environ.setdefault(
+    "REFRESH_TOKEN_SECRET_KEY",
+    "test-refresh-token-secret-key-at-least-32-bytes-long",
+)
 
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from datetime import datetime as dt

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -7,12 +7,44 @@ from src.config import Settings
 
 def _build_settings(**overrides: object) -> Settings:
     defaults: dict[str, object] = {
-        "SECRET_KEY": "test-secret",
-        "REFRESH_TOKEN_SECRET_KEY": "test-refresh-secret",
+        "SECRET_KEY": "test-secret-key-at-least-32-bytes-long",
+        "REFRESH_TOKEN_SECRET_KEY": "test-refresh-token-secret-key-at-least-32-bytes-long",
         "ADMIN_PASSWORD": "test-admin-password",
     }
     defaults.update(overrides)
     return Settings(**defaults)  # type: ignore[arg-type]
+
+
+class TestJwtSecretKeyValidation:
+    def test_empty_secret_key_rejected(self) -> None:
+        with pytest.raises(ValueError, match="SECRET_KEY must be set"):
+            _build_settings(SECRET_KEY="")
+
+    def test_short_secret_key_rejected(self) -> None:
+        with pytest.raises(ValueError, match="SECRET_KEY must be set"):
+            _build_settings(SECRET_KEY="short")
+
+    def test_insecure_example_secret_key_rejected(self) -> None:
+        with pytest.raises(ValueError, match="SECRET_KEY must be set"):
+            _build_settings(SECRET_KEY="123")
+
+    def test_empty_refresh_secret_key_rejected(self) -> None:
+        with pytest.raises(ValueError, match="REFRESH_TOKEN_SECRET_KEY must be set"):
+            _build_settings(REFRESH_TOKEN_SECRET_KEY="")
+
+    def test_short_refresh_secret_key_rejected(self) -> None:
+        with pytest.raises(ValueError, match="REFRESH_TOKEN_SECRET_KEY must be set"):
+            _build_settings(REFRESH_TOKEN_SECRET_KEY="random secret")
+
+    def test_exactly_32_byte_secret_keys_ok(self) -> None:
+        access = "a" * 32
+        refresh = "b" * 32
+        settings = _build_settings(
+            SECRET_KEY=access,
+            REFRESH_TOKEN_SECRET_KEY=refresh,
+        )
+        assert len(settings.SECRET_KEY) == 32
+        assert len(settings.REFRESH_TOKEN_SECRET_KEY) == 32
 
 
 class TestCorsOriginsValidation:


### PR DESCRIPTION
## Summary
- Add a `Settings` model validator that refuses to start the app when `SECRET_KEY` or `REFRESH_TOKEN_SECRET_KEY` is empty or shorter than 32 bytes, preventing deployments from silently falling back to forgeable JWT signing keys.
- Remove the insecure `SECRET_KEY=123` example from `.env.example` and replace it with a generation hint (also drops the stale `REFRESH_TOKEN_SECRET_KEY=random secret` line).
- Update test bootstrap (`conftest.py`) and `_build_settings` to provide valid 32+ byte secrets so existing tests still boot the app.

Fixes #302

## Test plan
- [x] `uv run ruff check` / `uv run ruff format` clean on changed files
- [x] `uv run pyright` clean on `src/config.py` and `tests/unit/test_config.py`
- [x] `uv run pytest` — 331 passed, including 6 new tests covering empty, short, insecure, and exactly-32-byte secrets for both keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)