### PR TITLE
Disable API docs in production (#307)

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -153,12 +153,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     await dispose_engine()
 
 
+_docs_enabled = settings.ENVIRONMENT != "production"
+
 app = FastAPI(
     title=settings.PROJECT_NAME,
     version=settings.VERSION,
-    docs_url=f"{settings.API_V1_PREFIX}/docs",
-    redoc_url=f"{settings.API_V1_PREFIX}/redoc",
-    openapi_url=f"{settings.API_V1_PREFIX}/openapi.json",
+    docs_url=f"{settings.API_V1_PREFIX}/docs" if _docs_enabled else None,
+    redoc_url=f"{settings.API_V1_PREFIX}/redoc" if _docs_enabled else None,
+    openapi_url=f"{settings.API_V1_PREFIX}/openapi.json" if _docs_enabled else None,
     lifespan=lifespan,
 )
 
@@ -373,11 +375,13 @@ async def health() -> dict[str, str]:
 @app.get(f"{settings.API_V1_PREFIX}/")
 async def api_root() -> dict[str, Any]:
     """API root endpoint."""
-    return {
+    response: dict[str, Any] = {
         "message": "crossbill API v1",
         "version": settings.VERSION,
-        "docs": f"{settings.API_V1_PREFIX}/docs",
     }
+    if _docs_enabled:
+        response["docs"] = f"{settings.API_V1_PREFIX}/docs"
+    return response
 
 
 # Mount static files for frontend assets (JS, CSS, etc.)


### PR DESCRIPTION
## Summary
- Gate Swagger (`/api/v1/docs`), Redoc (`/api/v1/redoc`), and the OpenAPI schema on `ENVIRONMENT != "production"` so production deployments no longer leak the full API surface.
- Stop advertising the docs URL from the `/api/v1/` root response when docs are disabled.

Fixes #307

## Test plan
- [ ] `ENVIRONMENT=production` → `GET /api/v1/docs`, `/api/v1/redoc`, `/api/v1/openapi.json` all return 404
- [ ] Non-production env → docs endpoints still reachable
- [ ] `GET /api/v1/` omits the `docs` key in production and includes it otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)