### PR TITLE
Add missing security headers (HSTS, CSP, Permissions-Policy)

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -242,11 +242,11 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
             response.headers["Content-Security-Policy"] = (
                 "default-src 'self'; "
-                "script-src 'self' https://static.cloudflareinsights.com 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM='; "
+                "script-src 'self'; "
                 "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
                 "img-src 'self' data: blob:; "
                 "font-src 'self' https://fonts.gstatic.com; "
-                "connect-src 'self' https://cloudflareinsights.com; "
+                "connect-src 'self'; "
                 "frame-ancestors 'none'; "
                 "base-uri 'self'; "
                 "form-action 'self'"

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -242,11 +242,11 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
             response.headers["Content-Security-Policy"] = (
                 "default-src 'self'; "
-                "script-src 'self' https://static.cloudflareinsights.com; "
+                "script-src 'self' https://static.cloudflareinsights.com 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM='; "
                 "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
                 "img-src 'self' data: blob:; "
                 "font-src 'self' https://fonts.gstatic.com; "
-                "connect-src 'self'; "
+                "connect-src 'self' https://cloudflareinsights.com; "
                 "frame-ancestors 'none'; "
                 "base-uri 'self'; "
                 "form-action 'self'"

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -234,8 +234,23 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["X-Frame-Options"] = "DENY"
+        response.headers["Permissions-Policy"] = (
+            "camera=(), microphone=(), geolocation=(), payment=()"
+        )
         if settings.ENVIRONMENT != "development":
             response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+            response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
+            response.headers["Content-Security-Policy"] = (
+                "default-src 'self'; "
+                "script-src 'self'; "
+                "style-src 'self' 'unsafe-inline'; "
+                "img-src 'self' data: blob:; "
+                "font-src 'self'; "
+                "connect-src 'self'; "
+                "frame-ancestors 'none'; "
+                "base-uri 'self'; "
+                "form-action 'self'"
+            )
         return response
 
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -242,10 +242,10 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
             response.headers["Content-Security-Policy"] = (
                 "default-src 'self'; "
-                "script-src 'self'; "
-                "style-src 'self' 'unsafe-inline'; "
+                "script-src 'self' https://static.cloudflareinsights.com; "
+                "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
                 "img-src 'self' data: blob:; "
-                "font-src 'self'; "
+                "font-src 'self' https://fonts.gstatic.com; "
                 "connect-src 'self'; "
                 "frame-ancestors 'none'; "
                 "base-uri 'self'; "


### PR DESCRIPTION
## Summary
- Adds `Strict-Transport-Security` (HSTS) and `Content-Security-Policy` headers in non-development environments
- Adds `Permissions-Policy` header disabling unused browser features (camera, microphone, geolocation, payment) in all environments
- CSP is restrictive by default (`default-src 'self'`), with `'unsafe-inline'` for styles (React) and `data:`/`blob:` for images

Fixes #306

## Test plan
- [ ] Verify HSTS and CSP headers are present in staging/production responses
- [ ] Verify HSTS and CSP headers are absent in development
- [ ] Verify Permissions-Policy header is present in all environments
- [ ] Confirm the SPA loads correctly with the new CSP (scripts, styles, images, fonts, API calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)