### PR TITLE
Trust X-Forwarded-* headers in uvicorn; switch nightly build to buildx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,4 +69,4 @@ ENV PYTHONUNBUFFERED=1
 ENV PORT=8000
 
 # Run database migrations and start uvicorn
-CMD ["sh", "-c", "alembic upgrade head && uvicorn src.main:app --host 0.0.0.0 --port ${PORT}"]
+CMD ["sh", "-c", "alembic upgrade head && uvicorn src.main:app --host 0.0.0.0 --port ${PORT} --proxy-headers --forwarded-allow-ips='*'"]

--- a/scripts/build-for-docker-hub.sh
+++ b/scripts/build-for-docker-hub.sh
@@ -1,21 +1,28 @@
 #!/bin/bash
 # Usage: ./build-for-docker-hub.sh
-# Builds and pushes nightly release to Docker Hub with a unique tag
-# Stable releases should be done by CI
+# Builds and pushes nightly release to Docker Hub with a unique tag.
+# Stable releases should be done by CI.
+#
+# Requires `docker buildx` (BuildKit). Bundled with Docker Engine 23+ on Linux.
+# On macOS with the Homebrew docker CLI (no Docker Desktop):
+#   brew install docker-buildx
+#   mkdir -p ~/.docker/cli-plugins
+#   ln -sfn "$(brew --prefix)/opt/docker-buildx/bin/docker-buildx" \
+#     ~/.docker/cli-plugins/docker-buildx
 
 set -e # Exit on error
 
 TIMESTAMP=$(date +%Y%m%d%H%M%S)
 UNIQUE_TAG="nightly-${TIMESTAMP}"
 
-echo "Building nightly release (${UNIQUE_TAG})..."
-export DOCKER_DEFAULT_PLATFORM=linux/amd64
-docker build -t crossbill:nightly -f ./Dockerfile .
-docker tag crossbill:nightly tumetsu/crossbill:nightly
-docker tag crossbill:nightly tumetsu/crossbill:${UNIQUE_TAG}
+echo "Building and pushing nightly release (${UNIQUE_TAG})..."
 
-echo "Pushing to docker registry..."
-docker push tumetsu/crossbill:nightly
-docker push tumetsu/crossbill:${UNIQUE_TAG}
+docker buildx build \
+  --platform linux/amd64 \
+  -t tumetsu/crossbill:nightly \
+  -t "tumetsu/crossbill:${UNIQUE_TAG}" \
+  -f ./Dockerfile \
+  --push \
+  .
 
 echo "Pushed tags: nightly, ${UNIQUE_TAG}"


### PR DESCRIPTION
## Summary

- Pass `--proxy-headers --forwarded-allow-ips='*'` to uvicorn in the root `Dockerfile` so `request.client.host` reflects the real client IP instead of Railway's edge proxy (`100.64.0.x`). Restores per-IP rate limiting on the auth routes (`@limiter.limit("5/minute")` on login/register, `10/minute` on refresh — all keyed via slowapi's `get_remote_address`) and makes the structured request logs in `backend/src/main.py` useful again for identifying abusive clients. Spotted while investigating vulnerability-scanner bursts against `/.env`, `/API/.env`, `/Dockerfile`, etc. — all of which surfaced as a single proxy IP in logs.
- Switch `scripts/build-for-docker-hub.sh` from the deprecated legacy builder to `docker buildx build --push`. Consolidates the previous build → tag → tag → push → push sequence into one invocation that tags both `:nightly` and the timestamped unique tag and streams to the registry without loading locally. Drops `DOCKER_DEFAULT_PLATFORM` in favor of explicit `--platform linux/amd64`. Header comment documents the buildx prerequisite for macOS users on Colima (no Docker Desktop).

## Test plan

- [ ] After Railway deploy, `curl https://<railway-host>/api/v1/health` from a known public IP and confirm the `request_started` structured log line shows `client_host=<your-public-ip>` rather than `100.64.0.x`.
- [ ] Confirm `X-Request-ID` response header is still present and the log line carries the real client IP.
- [ ] Hit `/api/v1/auth/login` 6+ times in under a minute with bad credentials from one client; confirm the 6th returns 429. Then repeat from a second client/IP and confirm it is bucketed separately (the second client should not be blocked by the first client's bucket).
- [ ] Run `make release-nightly` locally with `docker-buildx` installed; confirm no deprecation warning, both `tumetsu/crossbill:nightly` and `tumetsu/crossbill:nightly-<timestamp>` appear on Docker Hub, and the build runs on Linux CI hosts where buildx is bundled with Docker Engine 23+.