### PR TITLE
fix: replace BaseHTTPMiddleware with pure ASGI to stop FileResponse t…

### DIFF
--- a/backend/src/infrastructure/common/rate_limit.py
+++ b/backend/src/infrastructure/common/rate_limit.py
@@ -8,7 +8,10 @@ overridden by them.
 """
 
 from slowapi import Limiter
+from slowapi.middleware import _ASGIMiddlewareResponder  # pyright: ignore[reportPrivateUsage]
 from slowapi.util import get_remote_address
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from src.config import get_settings
 
@@ -20,3 +23,51 @@ limiter = Limiter(
     enabled=_settings.RATE_LIMIT_ENABLED,
     headers_enabled=True,
 )
+
+
+class _FixedResponder(_ASGIMiddlewareResponder):
+    """slowapi 0.1.9 re-sends initial_message for every body chunk, which makes
+    uvicorn raise on multi-chunk responses (e.g. FileResponse for a JS bundle).
+    Send it exactly once and pass through other message types unchanged.
+    """
+
+    _initial_sent: bool = False
+
+    async def send_wrapper(self, message: Message) -> None:
+        msg_type = message["type"]
+
+        if msg_type == "http.response.start":
+            if not self._initial_sent:
+                self.initial_message = message
+            return
+
+        if msg_type == "http.response.body":
+            if not self._initial_sent:
+                if self.error_response:
+                    self.initial_message["status"] = self.error_response.status_code
+                if self.inject_headers:
+                    headers = MutableHeaders(raw=self.initial_message["headers"])
+                    self.limiter._inject_asgi_headers(  # pyright: ignore[reportPrivateUsage]
+                        headers, self.request.state.view_rate_limit
+                    )
+                await self.send(self.initial_message)
+                self._initial_sent = True
+            await self.send(message)
+            return
+
+        await self.send(message)
+
+
+class RateLimitMiddleware:
+    """ASGI rate-limit middleware that wraps slowapi but fixes its multi-chunk
+    initial-message bug.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        await _FixedResponder(self.app)(scope, receive, send)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -13,11 +13,12 @@ from typing import Any
 import structlog
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, JSONResponse, Response
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIASGIMiddleware
-from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from src.config import configure_logging, get_settings
 from src.database import dispose_engine, get_session_factory, initialize_database
@@ -191,74 +192,98 @@ async def rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONRe
     )
 
 
-# Add request ID middleware
-@app.middleware("http")
-async def add_request_id_and_logging(
-    request: Request, call_next: RequestResponseEndpoint
-) -> Response:
-    """Add request ID to each request and log request/response."""
-    request_id = str(uuid.uuid4())
-    request.state.request_id = request_id
+# Pure ASGI middleware (NOT BaseHTTPMiddleware): wrapping the body via
+# BaseHTTPMiddleware truncates FileResponse/StaticFiles bodies, which uvicorn
+# rejects with "Response content shorter than Content-Length".
+class RequestIdAndLoggingMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
 
-    # Bind request_id to context for all logs in this request
-    structlog.contextvars.clear_contextvars()
-    structlog.contextvars.bind_contextvars(request_id=request_id)
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
 
-    start_time = time.time()
+        request_id = str(uuid.uuid4())
+        scope.setdefault("state", {})["request_id"] = request_id
 
-    # Log incoming request
-    logger.info(
-        "request_started",
-        method=request.method,
-        path=request.url.path,
-        client_host=request.client.host if request.client else None,
-    )
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(request_id=request_id)
 
-    response = await call_next(request)
+        client = scope.get("client")
+        client_host = client[0] if client else None
+        method = scope.get("method")
+        path = scope.get("path")
 
-    # Calculate request duration
-    duration = time.time() - start_time
-
-    # Log completed request
-    logger.info(
-        "request_completed",
-        method=request.method,
-        path=request.url.path,
-        status_code=response.status_code,
-        duration_ms=round(duration * 1000, 2),
-    )
-
-    # Add request ID to response headers
-    response.headers["X-Request-ID"] = request_id
-
-    return response
-
-
-class SecurityHeadersMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
-        response = await call_next(request)
-        response.headers["X-Content-Type-Options"] = "nosniff"
-        response.headers["X-Frame-Options"] = "DENY"
-        response.headers["Permissions-Policy"] = (
-            "camera=(), microphone=(), geolocation=(), payment=()"
+        logger.info(
+            "request_started",
+            method=method,
+            path=path,
+            client_host=client_host,
         )
-        if settings.ENVIRONMENT != "development":
-            response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
-            response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
-            response.headers["Content-Security-Policy"] = (
-                "default-src 'self'; "
-                "script-src 'self'; "
-                "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
-                "img-src 'self' data: blob:; "
-                "font-src 'self' https://fonts.gstatic.com; "
-                "connect-src 'self'; "
-                "frame-ancestors 'none'; "
-                "base-uri 'self'; "
-                "form-action 'self'"
+
+        start_time = time.time()
+        status_code = 500
+
+        async def wrapped_send(message: Message) -> None:
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = message["status"]
+                MutableHeaders(raw=message["headers"])["X-Request-ID"] = request_id
+            await send(message)
+
+        try:
+            await self.app(scope, receive, wrapped_send)
+        finally:
+            duration = time.time() - start_time
+            logger.info(
+                "request_completed",
+                method=method,
+                path=path,
+                status_code=status_code,
+                duration_ms=round(duration * 1000, 2),
             )
-        return response
 
 
+class SecurityHeadersMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def wrapped_send(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(raw=message["headers"])
+                headers["X-Content-Type-Options"] = "nosniff"
+                headers["X-Frame-Options"] = "DENY"
+                headers["Permissions-Policy"] = (
+                    "camera=(), microphone=(), geolocation=(), payment=()"
+                )
+                if settings.ENVIRONMENT != "development":
+                    headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+                    headers["Strict-Transport-Security"] = (
+                        "max-age=31536000; includeSubDomains"
+                    )
+                    headers["Content-Security-Policy"] = (
+                        "default-src 'self'; "
+                        "script-src 'self'; "
+                        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+                        "img-src 'self' data: blob:; "
+                        "font-src 'self' https://fonts.gstatic.com; "
+                        "connect-src 'self'; "
+                        "frame-ancestors 'none'; "
+                        "base-uri 'self'; "
+                        "form-action 'self'"
+                    )
+            await send(message)
+
+        await self.app(scope, receive, wrapped_send)
+
+
+app.add_middleware(RequestIdAndLoggingMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)
 
 # Configure CORS

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -16,7 +16,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from slowapi.errors import RateLimitExceeded
-from slowapi.middleware import SlowAPIASGIMiddleware
 from starlette.datastructures import MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
@@ -31,7 +30,7 @@ from src.domain.common.exceptions import (
     EntityNotFoundError,
     ValidationError,
 )
-from src.infrastructure.common.rate_limit import limiter
+from src.infrastructure.common.rate_limit import RateLimitMiddleware, limiter
 from src.infrastructure.common.routers import settings as settings_router
 from src.infrastructure.identity.repositories.user_repository import UserRepository
 from src.infrastructure.identity.routers import auth, users
@@ -165,14 +164,13 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# Wire the shared rate limiter and install slowapi's middleware so
+# Wire the shared rate limiter and install our rate-limit middleware so
 # `default_limits` apply to every route (not only those with an explicit
-# `@limiter.limit(...)` decorator).
+# `@limiter.limit(...)` decorator). We use a local fix for slowapi's
+# SlowAPIASGIMiddleware, which re-sends http.response.start on every body
+# chunk and breaks multi-chunk streamed responses (FileResponse, StaticFiles).
 app.state.limiter = limiter
-# Use the ASGI variant (not SlowAPIMiddleware): SlowAPIMiddleware's
-# `sync_check_limits` falls back to slowapi's default text response when
-# the registered exception handler is a coroutine, which it is here.
-app.add_middleware(SlowAPIASGIMiddleware)
+app.add_middleware(RateLimitMiddleware)
 
 
 @app.exception_handler(RateLimitExceeded)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -262,9 +262,7 @@ class SecurityHeadersMiddleware:
                 )
                 if settings.ENVIRONMENT != "development":
                     headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
-                    headers["Strict-Transport-Security"] = (
-                        "max-age=31536000; includeSubDomains"
-                    )
+                    headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
                     headers["Content-Security-Policy"] = (
                         "default-src 'self'; "
                         "script-src 'self'; "

--- a/backend/tests/test_middleware_file_response.py
+++ b/backend/tests/test_middleware_file_response.py
@@ -1,9 +1,10 @@
-"""Regression test: middleware must not truncate FileResponse bodies.
+"""Regression tests: middleware must not break streamed FileResponse bodies.
 
-When the request-id and security-headers middlewares were implemented with
-Starlette's BaseHTTPMiddleware, FileResponse/StaticFiles bodies were re-streamed
-through a memory pipe and could end up shorter than the declared Content-Length,
-causing uvicorn to raise "Response content shorter than Content-Length".
+Two bugs were observed in production:
+1. Starlette's BaseHTTPMiddleware re-streamed FileResponse bodies through a
+   memory pipe, causing them to be truncated below the declared Content-Length.
+2. slowapi 0.1.9's SlowAPIASGIMiddleware re-sends http.response.start on every
+   body chunk, which uvicorn rejects on multi-chunk responses.
 """
 
 from pathlib import Path
@@ -13,12 +14,25 @@ from fastapi import FastAPI
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from httpx import ASGITransport, AsyncClient
+from slowapi import Limiter
+from slowapi.util import get_remote_address
 
+from src.infrastructure.common.rate_limit import RateLimitMiddleware
 from src.main import RequestIdAndLoggingMiddleware, SecurityHeadersMiddleware
 
 
-def _build_app(static_dir: Path) -> FastAPI:
+def _build_app(static_dir: Path, *, with_rate_limit: bool = False) -> FastAPI:
     app = FastAPI()
+    if with_rate_limit:
+        # Enabled limiter with headers — exercises slowapi's send_wrapper path
+        # that mishandled multi-chunk responses.
+        app.state.limiter = Limiter(
+            key_func=get_remote_address,
+            default_limits=["1000/minute"],
+            enabled=True,
+            headers_enabled=True,
+        )
+        app.add_middleware(RateLimitMiddleware)
     app.add_middleware(RequestIdAndLoggingMiddleware)
     app.add_middleware(SecurityHeadersMiddleware)
     app.mount("/assets", StaticFiles(directory=str(static_dir)), name="assets")
@@ -32,9 +46,13 @@ def _build_app(static_dir: Path) -> FastAPI:
 
 @pytest.fixture
 def static_dir(tmp_path: Path) -> Path:
-    payload = b"x" * 65536  # 64 KiB — large enough to span multiple chunks
+    # 256 KiB — guarantees multiple 64 KiB chunks in FileResponse.
+    payload = b"x" * (256 * 1024)
     (tmp_path / "payload.bin").write_bytes(payload)
     return tmp_path
+
+
+EXPECTED_SIZE = 256 * 1024
 
 
 @pytest.mark.asyncio
@@ -44,9 +62,9 @@ async def test_file_response_body_not_truncated(static_dir: Path) -> None:
         response = await client.get("/file")
 
     assert response.status_code == 200
-    assert response.headers["content-length"] == "65536"
-    assert len(response.content) == 65536
-    assert response.content == b"x" * 65536
+    assert response.headers["content-length"] == str(EXPECTED_SIZE)
+    assert len(response.content) == EXPECTED_SIZE
+    assert response.content == b"x" * EXPECTED_SIZE
 
 
 @pytest.mark.asyncio
@@ -56,8 +74,8 @@ async def test_staticfiles_body_not_truncated(static_dir: Path) -> None:
         response = await client.get("/assets/payload.bin")
 
     assert response.status_code == 200
-    assert response.headers["content-length"] == "65536"
-    assert len(response.content) == 65536
+    assert response.headers["content-length"] == str(EXPECTED_SIZE)
+    assert len(response.content) == EXPECTED_SIZE
 
 
 @pytest.mark.asyncio
@@ -69,3 +87,19 @@ async def test_request_id_and_security_headers_present(static_dir: Path) -> None
     assert response.headers.get("x-request-id")
     assert response.headers["x-content-type-options"] == "nosniff"
     assert response.headers["x-frame-options"] == "DENY"
+
+
+@pytest.mark.asyncio
+async def test_multi_chunk_response_through_rate_limiter(static_dir: Path) -> None:
+    """slowapi 0.1.9's send_wrapper would re-send http.response.start for every
+    body chunk. With multiple chunks this corrupts the response; uvicorn rejects
+    it. The fix sends initial_message once.
+    """
+    app = _build_app(static_dir, with_rate_limit=True)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/file")
+
+    assert response.status_code == 200
+    assert len(response.content) == EXPECTED_SIZE
+    # Rate limit headers injected once on the (single) http.response.start.
+    assert response.headers.get("x-ratelimit-limit")

--- a/backend/tests/test_middleware_file_response.py
+++ b/backend/tests/test_middleware_file_response.py
@@ -1,0 +1,71 @@
+"""Regression test: middleware must not truncate FileResponse bodies.
+
+When the request-id and security-headers middlewares were implemented with
+Starlette's BaseHTTPMiddleware, FileResponse/StaticFiles bodies were re-streamed
+through a memory pipe and could end up shorter than the declared Content-Length,
+causing uvicorn to raise "Response content shorter than Content-Length".
+"""
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from httpx import ASGITransport, AsyncClient
+
+from src.main import RequestIdAndLoggingMiddleware, SecurityHeadersMiddleware
+
+
+def _build_app(static_dir: Path) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(RequestIdAndLoggingMiddleware)
+    app.add_middleware(SecurityHeadersMiddleware)
+    app.mount("/assets", StaticFiles(directory=str(static_dir)), name="assets")
+
+    @app.get("/file")
+    async def serve_file() -> FileResponse:  # pyright: ignore[reportUnusedFunction]
+        return FileResponse(static_dir / "payload.bin")
+
+    return app
+
+
+@pytest.fixture
+def static_dir(tmp_path: Path) -> Path:
+    payload = b"x" * 65536  # 64 KiB — large enough to span multiple chunks
+    (tmp_path / "payload.bin").write_bytes(payload)
+    return tmp_path
+
+
+@pytest.mark.asyncio
+async def test_file_response_body_not_truncated(static_dir: Path) -> None:
+    app = _build_app(static_dir)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/file")
+
+    assert response.status_code == 200
+    assert response.headers["content-length"] == "65536"
+    assert len(response.content) == 65536
+    assert response.content == b"x" * 65536
+
+
+@pytest.mark.asyncio
+async def test_staticfiles_body_not_truncated(static_dir: Path) -> None:
+    app = _build_app(static_dir)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/assets/payload.bin")
+
+    assert response.status_code == 200
+    assert response.headers["content-length"] == "65536"
+    assert len(response.content) == 65536
+
+
+@pytest.mark.asyncio
+async def test_request_id_and_security_headers_present(static_dir: Path) -> None:
+    app = _build_app(static_dir)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/file")
+
+    assert response.headers.get("x-request-id")
+    assert response.headers["x-content-type-options"] == "nosniff"
+    assert response.headers["x-frame-options"] == "DENY"


### PR DESCRIPTION
…runcation

BaseHTTPMiddleware re-streams response bodies through a memory pipe, which truncated FileResponse/StaticFiles bodies and triggered uvicorn's "Response content shorter than Content-Length" RuntimeError, breaking the SPA frontend on Railway. Both the request-id/logging middleware and the security-headers middleware now wrap send and mutate http.response.start headers directly, leaving the body bytes untouched.